### PR TITLE
Introducing immutable borrows for function arguments

### DIFF
--- a/Language.md
+++ b/Language.md
@@ -8,7 +8,7 @@
       | array!(y, tau, c); (* fixed-length array declaration *)
       | poly!(y’, y, a); (* fixed-length polynomials *)    
       | field_integers!(y, c, c); (* abstract field integer declaration *)
-      | fn f([x: tau,]+) -> tau' { e } (* function *)
+      | fn f([x: (&)tau,]+) -> tau' { e } (* function *)
       | enum y { [z(tau),]+ } (* enum type *)
       | struct y { [f: tau,]+ } (* struct type *)
 
@@ -36,7 +36,7 @@
 
     Expression e :=
       | l (* literal *) | (u::)x (* variable *)
-      | (u::)(y::)f([e]+) (* function call *)
+      | (u::)(y::)f([(&)e]+); (* function call *)
       | e.f([e']+)  (* method call *)
       | e1.e2 (* field access *)
       | e1..e2 (* range *)

--- a/hacspec/src/array.rs
+++ b/hacspec/src/array.rs
@@ -61,7 +61,7 @@ macro_rules! _array_base {
             }
 
             #[cfg_attr(feature="use_attributes", library(hacspec))]
-            pub fn from_sub<A: SeqTrait<$t>>(input: A, start: usize, len: usize) -> Self {
+            pub fn from_sub<A: SeqTrait<$t>>(input: &A, start: usize, len: usize) -> Self {
                 let mut a = Self::new();
                 debug_assert_eq!(len, a.len());
                 a = a.update_sub(0, input, start, len);
@@ -69,17 +69,17 @@ macro_rules! _array_base {
             }
 
             #[cfg_attr(feature="use_attributes", library(hacspec))]
-            pub fn from_sub_range<A: SeqTrait<$t>>(input: A, r: Range<usize>) -> Self {
+            pub fn from_sub_range<A: SeqTrait<$t>>(input: &A, r: Range<usize>) -> Self {
                 Self::from_sub(input, r.start, r.end - r.start)
             }
 
             #[cfg_attr(feature="use_attributes", library(hacspec))]
-            pub fn sub(self, start_out: usize, len: usize) -> Seq<$t> {
+            pub fn sub(&self, start_out: usize, len: usize) -> Seq<$t> {
                 Seq::from_sub(self, start_out, len)
             }
 
             #[cfg_attr(feature="use_attributes", library(hacspec))]
-            pub fn subr(self, r: Range<usize>) -> Seq<$t> {
+            pub fn subr(&self, r: Range<usize>) -> Seq<$t> {
                 self.sub(r.start, r.end - r.start)
             }
 
@@ -107,7 +107,7 @@ macro_rules! _array_base {
 
             #[cfg_attr(feature="use_attributes", library(hacspec))]
             pub fn get_chunk(
-                self,
+                &self,
                 chunk_size: usize,
                 chunk_number: usize
             ) -> (usize, Seq<$t>) {
@@ -122,7 +122,7 @@ macro_rules! _array_base {
                 self,
                 chunk_size: usize,
                 chunk_number: usize,
-                input: A,
+                input: &A,
             ) -> Self {
                 let idx_start = chunk_size * chunk_number;
                 let len = self.get_chunk_len(chunk_size, chunk_number);
@@ -228,7 +228,7 @@ macro_rules! _array_base {
             // We can't use the [From] trait here because otherwise it would conflict with
             // the From<T> for T core implementation, as the array also implements the [SeqTrait].
             #[cfg_attr(feature="use_attributes", library(hacspec))]
-            pub fn from_seq<T: SeqTrait<$t>>(x: T) -> $name {
+            pub fn from_seq<T: SeqTrait<$t>>(x: &T) -> $name {
                 debug_assert_eq!(x.len(), $l);
                 let mut out = $name::new();
                 for i in 0..x.len() {

--- a/hacspec/src/array.rs
+++ b/hacspec/src/array.rs
@@ -290,7 +290,7 @@ macro_rules! _secret_array {
         /// **Warning:** declassifies secret integer types.
         impl $name {
             #[cfg_attr(feature="use_attributes", primitive(hacspec))]
-            pub fn declassify_eq(self, other: Self) -> bool {
+            pub fn declassify_eq(&self, other: &Self) -> bool {
                 self.0[..]
                     .iter()
                     .map(|x| <$t>::declassify(*x))
@@ -310,7 +310,7 @@ macro_rules! _secret_array {
             }
 
             #[cfg_attr(feature="use_attributes", primitive(hacspec))]
-            pub fn to_be_bytes(self) -> Seq<U8> {
+            pub fn to_be_bytes(&self) -> Seq<U8> {
                const FACTOR: usize = core::mem::size_of::<$t>();
                let mut out : Seq<U8> = Seq::new($l * FACTOR);
                for i in 0..$l {
@@ -324,7 +324,7 @@ macro_rules! _secret_array {
             }
 
             #[cfg_attr(feature="use_attributes", primitive(hacspec))]
-            pub fn to_le_bytes(self) -> Seq<U8> {
+            pub fn to_le_bytes(&self) -> Seq<U8> {
                const FACTOR: usize = core::mem::size_of::<$t>();
                let mut out : Seq<U8> = Seq::new($l * FACTOR);
                for i in 0..$l {

--- a/hacspec/src/seq.rs
+++ b/hacspec/src/seq.rs
@@ -46,24 +46,24 @@ macro_rules! declare_seq_with_contents_constraints_impl {
             }
 
             #[cfg_attr(feature="use_attributes", library(hacspec))]
-            pub fn sub(self, start_out: usize, len: usize) -> Self {
+            pub fn sub(&self, start_out: usize, len: usize) -> Self {
                 Self::from_sub(self, start_out, len)
             }
 
             #[cfg_attr(feature="use_attributes", library(hacspec))]
-            pub fn subr(self, r: Range<usize>) -> Self {
+            pub fn subr(&self, r: Range<usize>) -> Self {
                 self.sub(r.start, r.end - r.start)
             }
 
             #[cfg_attr(feature="use_attributes", library(hacspec))]
-            pub fn from_sub<A: SeqTrait<T>>(input: A, start: usize, len: usize) -> Self {
+            pub fn from_sub<A: SeqTrait<T>>(input: &A, start: usize, len: usize) -> Self {
                 let mut a = Self::new(len);
                 a = a.update_sub(0, input, start, len);
                 a
             }
 
             #[cfg_attr(feature="use_attributes", library(hacspec))]
-            pub fn from_sub_range<A: SeqTrait<T>>(input: A, r: Range<usize>) -> Self {
+            pub fn from_sub_range<A: SeqTrait<T>>(input: &A, r: Range<usize>) -> Self {
                 Self::from_sub(input, r.start, r.end - r.start)
             }
 
@@ -77,7 +77,7 @@ macro_rules! declare_seq_with_contents_constraints_impl {
 
             #[cfg_attr(feature="use_attributes", library(hacspec))]
             pub fn get_chunk(
-                self,
+                &self,
                 chunk_size: usize,
                 chunk_number: usize
             ) -> (usize, Self) {
@@ -96,7 +96,7 @@ macro_rules! declare_seq_with_contents_constraints_impl {
                 self,
                 chunk_size: usize,
                 chunk_number: usize,
-                input: A,
+                input: &A,
             ) -> Self {
                 let idx_start = chunk_size * chunk_number;
                 let len = if idx_start + chunk_size > self.len() {
@@ -210,7 +210,7 @@ macro_rules! declare_seq_with_contents_constraints_impl {
             }
 
             #[cfg_attr(feature="use_attributes", library(hacspec))]
-            pub fn from_seq<U: SeqTrait<T>>(x: U) -> $name<T> {
+            pub fn from_seq<U: SeqTrait<T>>(x: &U) -> $name<T> {
                 let mut tmp = $name::new(x.len());
                 for i in 0..x.len() {
                     tmp[i] = x[i];

--- a/hacspec/src/traits.rs
+++ b/hacspec/src/traits.rs
@@ -19,13 +19,13 @@ pub trait SeqTrait<T: Copy> : Index<usize, Output=T> + IndexMut<usize, Output=T>
     ///
     /// let mut s = Seq::<u8>::new(5);
     /// let tmp = Seq::<u8>::from_slice(&[2, 3]);
-    /// s = s.update_sub(2, tmp, 1, 1);
+    /// s = s.update_sub(2, &tmp, 1, 1);
     /// // assert_eq!(s, Seq::<u8>::from_array(&[0, 0, 3, 0, 0]));
     /// ```
     fn update_sub<A: SeqTrait<T>>(
         mut self,
         start_out: usize,
-        v: A,
+        v: &A,
         start_in: usize,
         len: usize,
     ) -> Self {
@@ -46,11 +46,11 @@ pub trait SeqTrait<T: Copy> : Index<usize, Output=T> + IndexMut<usize, Output=T>
     ///
     /// let mut s = Seq::<u8>::new(5);
     /// let tmp = Seq::<u8>::from_slice(&[2, 3]);
-    /// s = s.update(2, tmp);
+    /// s = s.update(2, &tmp);
     /// // assert_eq!(s, Seq::<u8>::from_array(&[0, 0, 2, 3, 0]));
     /// ```
     #[cfg_attr(feature="use_attributes", library(hacspec))]
-    fn update<A: SeqTrait<T>>(self, start: usize, v: A) -> Self {
+    fn update<A: SeqTrait<T>>(self, start: usize, v: &A) -> Self {
         let len = v.len();
         self.update_sub(start, v, 0, len)
     }
@@ -58,7 +58,7 @@ pub trait SeqTrait<T: Copy> : Index<usize, Output=T> + IndexMut<usize, Output=T>
     #[cfg_attr(feature="use_attributes", library(hacspec))]
     fn update_start<A: SeqTrait<T>>(
         self,
-        v: A
+        v: &A
     ) -> Self {
         let len = v.len();
         self.update_sub(0, v, 0, len)

--- a/spec-examples/src/aes_gcm/aes.rs
+++ b/spec-examples/src/aes_gcm/aes.rs
@@ -127,7 +127,7 @@ fn rounds_aes128(state: Block, key: Bytes144) -> Block {
 fn rounds_aes256(state: Block, key: Bytes208) -> Block {
     let mut out = state;
     for i in 0..key.num_chunks(BLOCKSIZE) {
-        let (_, key_block)  = key.clone().get_chunk(BLOCKSIZE, i);
+        let (_, key_block)  = key.get_chunk(BLOCKSIZE, i);
         out = aes_enc(out, RoundKey::from_seq(&key_block));
     }
     out

--- a/spec-examples/src/aes_gcm/aes.rs
+++ b/spec-examples/src/aes_gcm/aes.rs
@@ -120,7 +120,7 @@ fn rounds_aes128(state: Block, key: Bytes144) -> Block {
     let mut out = state;
     for i in 0..key.num_chunks(BLOCKSIZE) {
         let (_, key_block) = key.get_chunk(BLOCKSIZE, i);
-        out = aes_enc(out, RoundKey::from_seq(key_block));
+        out = aes_enc(out, RoundKey::from_seq(&key_block));
     }
     out
 }
@@ -128,23 +128,23 @@ fn rounds_aes256(state: Block, key: Bytes208) -> Block {
     let mut out = state;
     for i in 0..key.num_chunks(BLOCKSIZE) {
         let (_, key_block)  = key.clone().get_chunk(BLOCKSIZE, i);
-        out = aes_enc(out, RoundKey::from_seq(key_block));
+        out = aes_enc(out, RoundKey::from_seq(&key_block));
     }
     out
 }
 
 fn block_cipher_aes128(input: Block, key: Bytes176, nr: usize) -> Block {
-    let k0 = RoundKey::from_sub_range(key, 0..16);
-    let k = Bytes144::from_sub_range(key, 16..nr * 16);
-    let kn = RoundKey::from_sub(key, nr * 16, 16);
+    let k0 = RoundKey::from_sub_range(&key, 0..16);
+    let k = Bytes144::from_sub_range(&key, 16..nr * 16);
+    let kn = RoundKey::from_sub(&key, nr * 16, 16);
     let state = add_round_key(input, k0);
     let state = rounds_aes128(state, k);
     aes_enc_last(state, kn)
 }
 fn block_cipher_aes256(input: Block, key: Bytes240, nr: usize) -> Block {
-    let k0 = RoundKey::from_sub_range(key, 0..16);
-    let k = Bytes208::from_sub_range(key, 16..nr * 16);
-    let kn = RoundKey::from_sub(key, nr * 16, 16);
+    let k0 = RoundKey::from_sub_range(&key, 0..16);
+    let k = Bytes208::from_sub_range(&key, 16..nr * 16);
+    let kn = RoundKey::from_sub(&key, nr * 16, 16);
     let state = add_round_key(input, k0);
     let state = rounds_aes256(state, k);
     aes_enc_last(state, kn)
@@ -185,34 +185,34 @@ fn key_expansion_word(w0: Word, w1: Word, i: usize, nk: usize, nr: usize) -> Wor
 }
 
 fn key_expansion_aes128(key: Key128, nk: usize, nr: usize) -> Bytes176 {
-    let mut key_ex = Bytes176::new().update_start(key);
+    let mut key_ex = Bytes176::new().update_start(&key);
     let mut i: usize;
     for j in 0..40 {
         i = j + 4;
         let word = key_expansion_word(
-            Word::from_sub(key_ex, 4 * i - 16, 4),
-            Word::from_sub(key_ex, nk * i - 4, 4),
+            Word::from_sub(&key_ex, 4 * i - 16, 4),
+            Word::from_sub(&key_ex, nk * i - 4, 4),
             i,
             nk,
             nr,
         );
-        key_ex = key_ex.update(4 * i, word);
+        key_ex = key_ex.update(4 * i, &word);
     }
     key_ex
 }
 fn key_expansion_aes256(key: Key256, nk: usize, nr: usize) -> Bytes240 {
-    let mut key_ex = Bytes240::new().update_start(key);
+    let mut key_ex = Bytes240::new().update_start(&key);
     let mut i: usize;
     for j in 0..52 {
         i = j + 8;
         let word = key_expansion_word(
-            Word::from_sub(key_ex, 4 * i - 32, 4),
-            Word::from_sub(key_ex, 4 * i - 4, 4),
+            Word::from_sub(&key_ex, 4 * i - 32, 4),
+            Word::from_sub(&key_ex, 4 * i - 4, 4),
             i,
             nk,
             nr,
         );
-        key_ex = key_ex.update(4 * i, word);
+        key_ex = key_ex.update(4 * i, &word);
     }
     key_ex
 }
@@ -228,14 +228,14 @@ pub fn aes256_encrypt_block(k: Key256, input: Block, nk: usize, nr: usize) -> Bl
 
 pub(crate) fn aes128_ctr_keyblock(k: Key128, n: Nonce, c: U32, nk: usize, nr: usize) -> Block {
     let mut input = Block::new();
-    input = input.update(0, n);
-    input = input.update(12, U32_to_be_bytes(c));
+    input = input.update(0, &n);
+    input = input.update(12, &U32_to_be_bytes(c));
     aes128_encrypt_block(k, input, nk, nr)
 }
 pub(crate) fn aes256_ctr_keyblock(k: Key256, n: Nonce, c: U32, nk: usize, nr: usize) -> Block {
     let mut input = Block::new();
-    input = input.update(0, n);
-    input = input.update(12, U32_to_be_bytes(c));
+    input = input.update(0, &n);
+    input = input.update(12, &U32_to_be_bytes(c));
     aes256_encrypt_block(k, input, nk, nr)
 }
 
@@ -251,30 +251,30 @@ fn aes128_counter_mode(
     key: Key128,
     nonce: Nonce,
     counter: U32,
-    msg: ByteSeq,
+    msg: &ByteSeq,
     nk: usize,
     nr: usize,
 ) -> ByteSeq {
     let mut ctr = counter;
     let mut blocks_out = ByteSeq::new(msg.len());
     for i in 0..msg.num_chunks(BLOCKSIZE) {
-        let (block_len, msg_block) = msg.clone().get_chunk(BLOCKSIZE, i);
+        let (block_len, msg_block) = msg.get_chunk(BLOCKSIZE, i);
         if msg_block.len() == BLOCKSIZE {
             let key_block = aes128_ctr_keyblock(key, nonce, ctr, nk, nr);
             blocks_out = blocks_out.set_chunk(
                 BLOCKSIZE,
                 i,
-                xor_block(Block::from_seq(msg_block), key_block),
+                &xor_block(Block::from_seq(&msg_block), key_block),
             );
             ctr += U32(1);
         } else {
             // Last block that needs padding
             let keyblock = aes128_ctr_keyblock(key, nonce, ctr, nk, nr);
-            let last_block = Block::new().update_start(msg_block);
+            let last_block = Block::new().update_start(&msg_block);
             blocks_out = blocks_out.set_chunk(
                 BLOCKSIZE,
                 i,
-                xor_block(last_block, keyblock).subr(0..block_len),
+                &xor_block(last_block, keyblock).subr(0..block_len),
             );
         }
     }
@@ -284,31 +284,31 @@ fn aes256_counter_mode(
     key: Key256,
     nonce: Nonce,
     counter: U32,
-    msg: ByteSeq,
+    msg: &ByteSeq,
     nk: usize,
     nr: usize,
 ) -> ByteSeq {
     let mut ctr = counter;
     let mut blocks_out = ByteSeq::new(msg.len());
     for i in 0..msg.num_chunks(BLOCKSIZE) {
-        let (block_len, msg_block) = msg.clone().get_chunk(BLOCKSIZE, i);
+        let (block_len, msg_block) = msg.get_chunk(BLOCKSIZE, i);
         if msg_block.len() == BLOCKSIZE {
             let key_block = aes256_ctr_keyblock(key, nonce, ctr, nk, nr);
             blocks_out = blocks_out.set_chunk(
                 BLOCKSIZE,
                 i,
-                xor_block(Block::from_seq(msg_block), key_block),
+                &xor_block(Block::from_seq(&msg_block), key_block),
             );
             ctr += U32(1);
         } else {
             // Last block that needs padding
             let keyblock = aes256_ctr_keyblock(key, nonce, ctr, nk, nr);
             let last_block = Block::new();
-            let last_block = last_block.update_start(msg_block);
+            let last_block = last_block.update_start(&msg_block);
             blocks_out = blocks_out.set_chunk(
                 BLOCKSIZE,
                 i,
-                xor_block(last_block, keyblock).subr(0..block_len),
+                &xor_block(last_block, keyblock).subr(0..block_len),
             );
         }
     }
@@ -321,17 +321,17 @@ fn aes256_counter_mode(
 Nk =    4  |      8
 Nr =    8  |     14
 */
-pub fn aes128_encrypt(key: Key128, nonce: Nonce, counter: U32, msg: ByteSeq) -> ByteSeq {
+pub fn aes128_encrypt(key: Key128, nonce: Nonce, counter: U32, msg: &ByteSeq) -> ByteSeq {
     aes128_counter_mode(key, nonce, counter, msg, 4, 10)
 }
-pub fn aes128_decrypt(key: Key128, nonce: Nonce, counter: U32, ctxt: ByteSeq) -> ByteSeq {
+pub fn aes128_decrypt(key: Key128, nonce: Nonce, counter: U32, ctxt: &ByteSeq) -> ByteSeq {
     aes128_counter_mode(key, nonce, counter, ctxt, 4, 10)
 }
 
-pub fn aes256_encrypt(key: Key256, nonce: Nonce, counter: U32, msg: ByteSeq) -> ByteSeq {
+pub fn aes256_encrypt(key: Key256, nonce: Nonce, counter: U32, msg: &ByteSeq) -> ByteSeq {
     aes256_counter_mode(key, nonce, counter, msg, 8, 14)
 }
-pub fn aes256_decrypt(key: Key256, nonce: Nonce, counter: U32, ctxt: ByteSeq) -> ByteSeq {
+pub fn aes256_decrypt(key: Key256, nonce: Nonce, counter: U32, ctxt: &ByteSeq) -> ByteSeq {
     aes256_counter_mode(key, nonce, counter, ctxt, 8, 14)
 }
 

--- a/spec-examples/src/aes_gcm/aesgcm.rs
+++ b/spec-examples/src/aes_gcm/aesgcm.rs
@@ -9,7 +9,7 @@ use super::aes::{
 
 use super::gf128::{gmac, Key, Tag};
 
-fn pad_aad_msg(aad: ByteSeq, msg: ByteSeq) -> ByteSeq {
+fn pad_aad_msg(aad: &ByteSeq, msg: &ByteSeq) -> ByteSeq {
     let laad = aad.len();
     let lmsg = msg.len();
     let pad_aad = if laad % 16 == 0 {
@@ -27,11 +27,11 @@ fn pad_aad_msg(aad: ByteSeq, msg: ByteSeq) -> ByteSeq {
     padded_msg = padded_msg.update(pad_aad, msg);
     padded_msg = padded_msg.update(
         pad_aad + pad_msg,
-        U64_to_be_bytes(U64(laad as u64) * U64(8)),
+        &U64_to_be_bytes(U64(laad as u64) * U64(8)),
     );
     padded_msg = padded_msg.update(
         pad_aad + pad_msg + 8,
-        U64_to_be_bytes(U64(lmsg as u64) * U64(8)),
+        &U64_to_be_bytes(U64(lmsg as u64) * U64(8)),
     );
     padded_msg
 }
@@ -39,8 +39,8 @@ fn pad_aad_msg(aad: ByteSeq, msg: ByteSeq) -> ByteSeq {
 pub fn encrypt_aes128(
     key: aes::Key128,
     iv: aes::Nonce,
-    aad: ByteSeq,
-    msg: ByteSeq,
+    aad: &ByteSeq,
+    msg: &ByteSeq,
 ) -> (ByteSeq, Tag) {
     let iv0 = aes::Nonce::new();
 
@@ -48,18 +48,18 @@ pub fn encrypt_aes128(
     let tag_mix = aes128_ctr_keyblock(key, iv, U32(1), 4, 10);
 
     let cipher_text = aes128_encrypt(key, iv, U32(2), msg);
-    let padded_msg = pad_aad_msg(aad, cipher_text.clone());
-    let tag = gmac(padded_msg, Key::from_seq(mac_key));
-    let tag = aes::xor_block(Block::from_seq(tag), tag_mix);
+    let padded_msg = pad_aad_msg(aad, &cipher_text);
+    let tag = gmac(&padded_msg, Key::from_seq(&mac_key));
+    let tag = aes::xor_block(Block::from_seq(&tag), tag_mix);
 
-    (cipher_text, Tag::from_seq(tag))
+    (cipher_text, Tag::from_seq(&tag))
 }
 
 pub fn encrypt_aes256(
     key: aes::Key256,
     iv: aes::Nonce,
-    aad: ByteSeq,
-    msg: ByteSeq,
+    aad: &ByteSeq,
+    msg: &ByteSeq,
 ) -> (ByteSeq, Tag) {
     let iv0 = aes::Nonce::new();
 
@@ -67,18 +67,18 @@ pub fn encrypt_aes256(
     let tag_mix = aes256_ctr_keyblock(key, iv, U32(1), 8, 14);
 
     let cipher_text = aes256_encrypt(key, iv, U32(2), msg);
-    let padded_msg = pad_aad_msg(aad, cipher_text.clone());
-    let tag = gmac(padded_msg, Key::from_seq(mac_key));
-    let tag = aes::xor_block(Block::from_seq(tag), tag_mix);
+    let padded_msg = pad_aad_msg(aad, &cipher_text);
+    let tag = gmac(&padded_msg, Key::from_seq(&mac_key));
+    let tag = aes::xor_block(Block::from_seq(&tag), tag_mix);
 
-    (cipher_text, Tag::from_seq(tag))
+    (cipher_text, Tag::from_seq(&tag))
 }
 
 pub fn decrypt_aes128(
     key: aes::Key128,
     iv: aes::Nonce,
-    aad: ByteSeq,
-    cipher_text: ByteSeq,
+    aad: &ByteSeq,
+    cipher_text: &ByteSeq,
     tag: Tag,
 ) -> Result<ByteSeq, String> {
     let iv0 = aes::Nonce::new();
@@ -86,11 +86,11 @@ pub fn decrypt_aes128(
     let mac_key = aes128_ctr_keyblock(key, iv0, U32(0), 4, 10);
     let tag_mix = aes128_ctr_keyblock(key, iv, U32(1), 4, 10);
 
-    let padded_msg = pad_aad_msg(aad, cipher_text.clone());
-    let my_tag = gmac(padded_msg, Key::from_seq(mac_key));
-    let my_tag = aes::xor_block(Block::from_seq(my_tag), tag_mix);
+    let padded_msg = pad_aad_msg(aad, cipher_text);
+    let my_tag = gmac(&padded_msg, Key::from_seq(&mac_key));
+    let my_tag = aes::xor_block(Block::from_seq(&my_tag), tag_mix);
 
-    if my_tag.declassify_eq(Block::from_seq(tag)) {
+    if my_tag.declassify_eq(Block::from_seq(&tag)) {
         Ok(aes128_decrypt(key, iv, U32(2), cipher_text))
     } else {
         Err("Mac verification failed".to_string())
@@ -100,8 +100,8 @@ pub fn decrypt_aes128(
 pub fn decrypt_aes256(
     key: aes::Key256,
     iv: aes::Nonce,
-    aad: ByteSeq,
-    cipher_text: ByteSeq,
+    aad: &ByteSeq,
+    cipher_text: &ByteSeq,
     tag: Tag,
 ) -> Result<ByteSeq, String> {
     let iv0 = aes::Nonce::new();
@@ -109,11 +109,11 @@ pub fn decrypt_aes256(
     let mac_key = aes256_ctr_keyblock(key, iv0, U32(0), 8, 14);
     let tag_mix = aes256_ctr_keyblock(key, iv, U32(1), 8, 14);
 
-    let padded_msg = pad_aad_msg(aad, cipher_text.clone());
-    let my_tag = gmac(padded_msg, Key::from_seq(mac_key));
-    let my_tag = aes::xor_block(Block::from_seq(my_tag), tag_mix);
+    let padded_msg = pad_aad_msg(aad, cipher_text);
+    let my_tag = gmac(&padded_msg, Key::from_seq(&mac_key));
+    let my_tag = aes::xor_block(Block::from_seq(&my_tag), tag_mix);
 
-    if my_tag.declassify_eq(Block::from_seq(tag)) {
+    if my_tag.declassify_eq(Block::from_seq(&tag)) {
         Ok(aes256_decrypt(key, iv, U32(2), cipher_text))
     } else {
         Err("Mac verification failed".to_string())

--- a/spec-examples/src/aes_gcm/aesgcm.rs
+++ b/spec-examples/src/aes_gcm/aesgcm.rs
@@ -90,7 +90,7 @@ pub fn decrypt_aes128(
     let my_tag = gmac(&padded_msg, Key::from_seq(&mac_key));
     let my_tag = aes::xor_block(Block::from_seq(&my_tag), tag_mix);
 
-    if my_tag.declassify_eq(Block::from_seq(&tag)) {
+    if my_tag.declassify_eq(&Block::from_seq(&tag)) {
         Ok(aes128_decrypt(key, iv, U32(2), cipher_text))
     } else {
         Err("Mac verification failed".to_string())
@@ -113,7 +113,7 @@ pub fn decrypt_aes256(
     let my_tag = gmac(&padded_msg, Key::from_seq(&mac_key));
     let my_tag = aes::xor_block(Block::from_seq(&my_tag), tag_mix);
 
-    if my_tag.declassify_eq(Block::from_seq(&tag)) {
+    if my_tag.declassify_eq(&Block::from_seq(&tag)) {
         Ok(aes256_decrypt(key, iv, U32(2), cipher_text))
     } else {
         Err("Mac verification failed".to_string())

--- a/spec-examples/src/blake2/blake2b.rs
+++ b/spec-examples/src/blake2/blake2b.rs
@@ -82,8 +82,8 @@ fn compress(h: State, m: Buffer, t: Counter, last_block: bool) -> State {
     let m = make_u64array(m);
 
     // Prepare.
-    v = v.update_sub(0, h, 0, 8);
-    v = v.update_sub(8, IV, 0, 8);
+    v = v.update_sub(0, &h, 0, 8);
+    v = v.update_sub(8, &IV, 0, 8);
     v[12] ^= U64(t[0]);
     v[13] ^= U64(t[1]);
     if last_block {
@@ -134,21 +134,21 @@ fn get_byte(x: U64, i: usize) -> U8 {
     }
 }
 
-pub fn blake2b(data: ByteSeq) -> Digest {
+pub fn blake2b(data: &ByteSeq) -> Digest {
     let mut h = IV;
     // This only supports the 512 version without key.
     h[0] = h[0] ^ U64(0x0101_0000) ^ U64(64);
 
     let mut t = Counter([0; 2]);
     for i in 0..data.num_chunks(128) {
-        let (block_len, block) = data.clone().get_chunk(128, i);
+        let (block_len, block) = data.get_chunk(128, i);
         if block_len == 128 {
             t = inc_counter(t, 128);
-            h = compress(h, Buffer::from_seq(block), t, false);
+            h = compress(h, Buffer::from_seq(&block), t, false);
         } else {
             // Pad last bits of data to a full block.
             t = inc_counter(t, block_len as u64);
-            let compress_input = Buffer::new().update_start(block);
+            let compress_input = Buffer::new().update_start(&block);
             h = compress(h, compress_input, t, true);
         }
     }

--- a/spec-examples/src/chacha20_poly1305/chacha20.rs
+++ b/spec-examples/src/chacha20_poly1305/chacha20.rs
@@ -52,18 +52,18 @@ pub fn block_init(key: Key, ctr: U32, iv: IV) -> State {
         U32(0x3320_646e),
         U32(0x7962_2d32),
         U32(0x6b20_6574),
-        U32_from_le_bytes(U32Word::from_sub_range(key, 0..4)),
-        U32_from_le_bytes(U32Word::from_sub_range(key, 4..8)),
-        U32_from_le_bytes(U32Word::from_sub_range(key, 8..12)),
-        U32_from_le_bytes(U32Word::from_sub_range(key, 12..16)),
-        U32_from_le_bytes(U32Word::from_sub_range(key, 16..20)),
-        U32_from_le_bytes(U32Word::from_sub_range(key, 20..24)),
-        U32_from_le_bytes(U32Word::from_sub_range(key, 24..28)),
-        U32_from_le_bytes(U32Word::from_sub_range(key, 28..32)),
+        U32_from_le_bytes(U32Word::from_sub_range(&key, 0..4)),
+        U32_from_le_bytes(U32Word::from_sub_range(&key, 4..8)),
+        U32_from_le_bytes(U32Word::from_sub_range(&key, 8..12)),
+        U32_from_le_bytes(U32Word::from_sub_range(&key, 12..16)),
+        U32_from_le_bytes(U32Word::from_sub_range(&key, 16..20)),
+        U32_from_le_bytes(U32Word::from_sub_range(&key, 20..24)),
+        U32_from_le_bytes(U32Word::from_sub_range(&key, 24..28)),
+        U32_from_le_bytes(U32Word::from_sub_range(&key, 28..32)),
         ctr,
-        U32_from_le_bytes(U32Word::from_sub_range(iv, 0..4)),
-        U32_from_le_bytes(U32Word::from_sub_range(iv, 4..8)),
-        U32_from_le_bytes(U32Word::from_sub_range(iv, 8..12)),
+        U32_from_le_bytes(U32Word::from_sub_range(&iv, 0..4)),
+        U32_from_le_bytes(U32Word::from_sub_range(&iv, 4..8)),
+        U32_from_le_bytes(U32Word::from_sub_range(&iv, 8..12)),
     ])
 }
 
@@ -84,15 +84,15 @@ pub fn block(key: Key, ctr: U32, iv: IV) -> StateBytes {
     state_to_bytes(state)
 }
 
-pub fn chacha(key: Key, iv: IV, m: ByteSeq) -> Result<ByteSeq, String> {
+pub fn chacha(key: Key, iv: IV, m: &ByteSeq) -> Result<ByteSeq, String> {
     let mut ctr = U32(1);
     let mut blocks_out = ByteSeq::new(m.len());
     for i in 0..m.num_chunks(64) {
-        let (block_len, msg_block) = m.clone().get_chunk(64, i);
+        let (block_len, msg_block) = m.get_chunk(64, i);
         let key_block = block(key, ctr, iv);
         let msg_block_padded = StateBytes::new();
-        let msg_block_padded = msg_block_padded.update_start(msg_block);
-        blocks_out = blocks_out.set_chunk(64, i, (msg_block_padded ^ key_block).subr(0..block_len));
+        let msg_block_padded = msg_block_padded.update_start(&msg_block);
+        blocks_out = blocks_out.set_chunk(64, i, &(msg_block_padded ^ key_block).subr(0..block_len));
         ctr += U32(1);
     }
     Ok(blocks_out)

--- a/spec-examples/src/chacha20_poly1305/poly1305.rs
+++ b/spec-examples/src/chacha20_poly1305/poly1305.rs
@@ -22,18 +22,18 @@ public_nat_mod!(
 
 fn key_gen(key: Key, iv: IV) -> Key {
     let block = chacha20::block(key, U32(0), iv);
-    Key::from_sub_range(block, 0..32)
+    Key::from_sub_range(&block, 0..32)
 }
 
 fn encode_r(r: Block) -> FieldElement {
     let mut r_128 = U128Word::new();
-    r_128 = r_128.update_sub(0, r, 0, BLOCKSIZE);
+    r_128 = r_128.update_sub(0, &r, 0, BLOCKSIZE);
     let r_uint = U128_from_le_bytes(r_128);
     let r_uint = r_uint & U128(0x0fff_fffc_0fff_fffc_0fff_fffc_0fff_ffff);
     FieldElement::from_secret_literal(r_uint)
 }
 
-fn encode(block: ByteSeq) -> FieldElement {
+fn encode(block: &ByteSeq) -> FieldElement {
     let mut block_as_u128 = U128Word::new();
     let block_len = block.len();
     block_as_u128 = block_as_u128.update_sub(0, block, 0, min(16, block_len));
@@ -42,23 +42,23 @@ fn encode(block: ByteSeq) -> FieldElement {
     w_elem + l_elem
 }
 
-fn poly_inner(m: ByteSeq, r: FieldElement) -> FieldElement {
+fn poly_inner(m: &ByteSeq, r: FieldElement) -> FieldElement {
     let mut acc = FieldElement::from_literal(0);
     let m_len = m.len();
     for i in (0..m_len).step_by(BLOCKSIZE) {
         let block_len = min(BLOCKSIZE, m_len - i);
         let mut b = Seq::new(block_len);
-        b = b.update_sub(0, m.clone(), i, block_len);
-        acc = (acc + encode(b)) * r;
+        b = b.update_sub(0, m, i, block_len);
+        acc = (acc + encode(&b)) * r;
     }
     acc
 }
 
-pub fn poly(m: ByteSeq, key: Key) -> Tag {
+pub fn poly(m: &ByteSeq, key: Key) -> Tag {
     let s_elem = FieldElement::from_secret_literal(U128_from_le_bytes(U128Word::from_sub(
-        key, BLOCKSIZE, BLOCKSIZE,
+        &key, BLOCKSIZE, BLOCKSIZE,
     )));
-    let r_elem = encode_r(Block::from_sub_range(key, 0..BLOCKSIZE));
+    let r_elem = encode_r(Block::from_sub_range(&key, 0..BLOCKSIZE));
     let a = poly_inner(m, r_elem);
     let n = a + s_elem;
     // Note that n might be less than 16 byte -> zero-pad; but might also be
@@ -71,7 +71,7 @@ pub fn poly(m: ByteSeq, key: Key) -> Tag {
     tag
 }
 
-pub fn poly_mac(m: ByteSeq, key: Key, iv: IV) -> Tag {
+pub fn poly_mac(m: &ByteSeq, key: Key, iv: IV) -> Tag {
     let mac_key = key_gen(key, iv);
     poly(m, mac_key)
 }

--- a/spec-examples/src/curve25519/curve25519.rs
+++ b/spec-examples/src/curve25519/curve25519.rs
@@ -128,5 +128,5 @@ fn test_encode_decode_scalar() {
     assert_eq!(u_expected, u_);
 
     let u_encoded = encode_point(u_);
-    assert!(u.declassify_eq(u_encoded));
+    assert!(u.declassify_eq(&u_encoded));
 }

--- a/spec-examples/src/curve25519/curve25519.rs
+++ b/spec-examples/src/curve25519/curve25519.rs
@@ -44,7 +44,7 @@ fn decode_point(u: SerializedPoint) -> Point {
 fn encode_point(p: Point) -> SerializedPoint {
     let (x, y) = p;
     let b = x * y.inv();
-    SerializedPoint::new().update_start(b.to_byte_seq_le())
+    SerializedPoint::new().update_start(&b.to_byte_seq_le())
 }
 
 fn point_add_and_double(q: Point, (nq, nqp1): (Point, Point)) -> (Point, Point) {

--- a/spec-examples/src/fips202/fips202.rs
+++ b/spec-examples/src/fips202/fips202.rs
@@ -112,7 +112,7 @@ fn keccakf1600(mut s: State) -> State {
     s
 }
 
-fn absorb_block(mut s: State, block: ByteSeq) -> State {
+fn absorb_block(mut s: State, block: &ByteSeq) -> State {
     for (i, b) in block.iter().enumerate() {
         let w = i >> 3;
         let o = 8 * ((i & 7) as u32);
@@ -136,52 +136,52 @@ fn squeeze(mut s: State, nbytes: usize, rate: usize) -> ByteSeq {
     out
 }
 
-fn keccak(rate: usize, data: ByteSeq, p: u8, outbytes: usize) -> ByteSeq {
+fn keccak(rate: usize, data: &ByteSeq, p: u8, outbytes: usize) -> ByteSeq {
     let mut buf = ByteSeq::new(rate);
     let mut last_block_len = 0;
     let mut s = State::new();
 
     for i in 0..data.num_chunks(rate) {
-        let (block_len, block) = data.clone().get_chunk(rate, i);
+        let (block_len, block) = data.get_chunk(rate, i);
         if block_len == rate {
-            s = absorb_block(s, block);
+            s = absorb_block(s, &block);
         } else {
-            buf = buf.update_start(block);
+            buf = buf.update_start(&block);
             last_block_len = block_len;
         }
     }
     buf[last_block_len] = U8(p);
     buf[rate - 1] |= U8(128);
-    s = absorb_block(s, buf);
+    s = absorb_block(s, &buf);
 
     squeeze(s, outbytes, rate)
 }
 
-pub fn sha3224(data: ByteSeq) -> Digest224 {
+pub fn sha3224(data: &ByteSeq) -> Digest224 {
     let t = keccak(SHA3224_RATE, data, 0x06, 28);
-    Digest224::from_seq(t)
+    Digest224::from_seq(&t)
 }
 
-pub fn sha3256(data: ByteSeq) -> Digest256 {
+pub fn sha3256(data: &ByteSeq) -> Digest256 {
     let t = keccak(SHA3256_RATE, data, 0x06, 32);
-    Digest256::from_seq(t)
+    Digest256::from_seq(&t)
 }
 
-pub fn sha3384(data: ByteSeq) -> Digest384 {
+pub fn sha3384(data: &ByteSeq) -> Digest384 {
     let t = keccak(SHA3384_RATE, data, 0x06, 48);
-    Digest384::from_seq(t)
+    Digest384::from_seq(&t)
 }
 
-pub fn sha3512(data: ByteSeq) -> Digest512 {
+pub fn sha3512(data: &ByteSeq) -> Digest512 {
     let t = keccak(SHA3512_RATE, data, 0x06, 64);
-    Digest512::from_seq(t)
+    Digest512::from_seq(&t)
 }
 
-pub fn shake128(data: ByteSeq, outlen: usize) -> ByteSeq {
+pub fn shake128(data: &ByteSeq, outlen: usize) -> ByteSeq {
     keccak(SHAKE128_RATE, data, 0x1f, outlen)
 }
 
-pub fn shake256(data: ByteSeq, outlen: usize) -> ByteSeq {
+pub fn shake256(data: &ByteSeq, outlen: usize) -> ByteSeq {
     keccak(SHAKE256_RATE, data, 0x1f, outlen)
 }
 

--- a/spec-examples/src/sha2/sha2.rs
+++ b/spec-examples/src/sha2/sha2.rs
@@ -161,33 +161,33 @@ fn compress(block: Block, h_in: Hash) -> Hash {
     h
 }
 
-pub fn hash(msg: ByteSeq) -> Digest {
+pub fn hash(msg: &ByteSeq) -> Digest {
     let mut h = Hash::from_public_array([
         0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
         0x5be0cd19,
     ]);
     for i in 0..msg.num_chunks(BLOCK_SIZE) {
-        let (block_len, block) = msg.clone().get_chunk(BLOCK_SIZE, i);
+        let (block_len, block) = msg.get_chunk(BLOCK_SIZE, i);
         if block_len < BLOCK_SIZE {
             // Add padding for last block
             let mut last_block = Block::new();
-            let block = Block::new().update_start(block);
-            last_block = last_block.update(0, block);
+            let block = Block::new().update_start(&block);
+            last_block = last_block.update(0, &block);
             last_block[block_len] = U8(0x80);
             let len_bist: U64 = (msg.len() * 8).into();
             if block_len < BLOCK_SIZE - LEN_SIZE {
-                last_block = last_block.update(BLOCK_SIZE - LEN_SIZE, U64_to_be_bytes(len_bist));
+                last_block = last_block.update(BLOCK_SIZE - LEN_SIZE, &U64_to_be_bytes(len_bist));
                 h = compress(last_block, h);
             } else {
                 let mut pad_block = Block::new();
-                pad_block = pad_block.update(BLOCK_SIZE - LEN_SIZE, U64_to_be_bytes(len_bist));
+                pad_block = pad_block.update(BLOCK_SIZE - LEN_SIZE, &U64_to_be_bytes(len_bist));
                 h = compress(last_block, h);
                 h = compress(pad_block, h);
             }
         } else {
-            let compress_input = Block::new().update_start(block);
+            let compress_input = Block::new().update_start(&block);
             h = compress(compress_input, h);
         }
     }
-    Digest::from_seq(h.to_be_bytes())
+    Digest::from_seq(&h.to_be_bytes())
 }

--- a/spec-examples/tests/test_aes.rs
+++ b/spec-examples/tests/test_aes.rs
@@ -2,17 +2,17 @@ use hacspec::prelude::*;
 
 use hacspec_examples::aes_gcm::aes::*;
 
-fn aes_128_enc_dec_test(m: ByteSeq, key: Key128, iv: Nonce, ctr: U32, ctxt: Option<ByteSeq>) {
-    let c = aes128_encrypt(key, iv, ctr, m.clone());
-    let m_dec = aes128_decrypt(key, iv, ctr, c.clone());
+fn aes_128_enc_dec_test(m: &ByteSeq, key: Key128, iv: Nonce, ctr: U32, ctxt: Option<&ByteSeq>) {
+    let c = aes128_encrypt(key, iv, ctr, m);
+    let m_dec = aes128_decrypt(key, iv, ctr, &c);
     assert_bytes_eq!(m, m_dec);
     if ctxt.is_some() {
         assert_bytes_eq!(c, ctxt.unwrap());
     }
 }
-fn aes_256_enc_dec_test(m: ByteSeq, key: Key256, iv: Nonce, ctr: U32, ctxt: Option<ByteSeq>) {
-    let c = aes256_encrypt(key, iv, ctr, m.clone());
-    let m_dec = aes256_decrypt(key, iv, ctr, c.clone());
+fn aes_256_enc_dec_test(m: &ByteSeq, key: Key256, iv: Nonce, ctr: U32, ctxt: Option<&ByteSeq>) {
+    let c = aes256_encrypt(key, iv, ctr, m);
+    let m_dec = aes256_decrypt(key, iv, ctr, &c);
     assert_bytes_eq!(m, m_dec);
     if ctxt.is_some() {
         assert_bytes_eq!(c, ctxt.unwrap());
@@ -24,7 +24,7 @@ fn test_enc_dec() {
     let key = Key128::random();
     let iv = Nonce::random();
     let m = ByteSeq::random(40);
-    aes_128_enc_dec_test(m, key, iv, U32(0), None);
+    aes_128_enc_dec_test(&m, key, iv, U32(0), None);
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_kat1() {
         0x87, 0x4d, 0x61, 0x91, 0xb6, 0x20, 0xe3, 0x26, 0x1b, 0xef, 0x68, 0x64, 0x99, 0x0d, 0xb6,
         0xce
     ]);
-    aes_128_enc_dec_test(msg, key, nonce, ctr, Some(ctxt));
+    aes_128_enc_dec_test(&msg, key, nonce, ctr, Some(&ctxt));
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn test_kat2() {
         0x88, 0xEB, 0x2E, 0x1E, 0xFC, 0x46, 0xDA, 0x57, 0xC8, 0xFC, 0xE6, 0x30, 0xDF, 0x91, 0x41,
         0xBE, 0x28
     ]);
-    aes_128_enc_dec_test(msg, key, nonce, U32(ctr), Some(ctxt));
+    aes_128_enc_dec_test(&msg, key, nonce, U32(ctr), Some(&ctxt));
 }
 #[test]
 //https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/AES_CTR.pdf
@@ -91,5 +91,5 @@ fn test_aes256_1() {
         0x28
     ]);
 
-    aes_256_enc_dec_test(msg, key, nonce, ctr, Some(ctxt));
+    aes_256_enc_dec_test(&msg, key, nonce, ctr, Some(&ctxt));
 }

--- a/spec-examples/tests/test_aesgcm.rs
+++ b/spec-examples/tests/test_aesgcm.rs
@@ -75,7 +75,7 @@ fn kat_test() {
         let aad = ByteSeq::from_hex(kat.aad);
         let exp_cipher = ByteSeq::from_hex(kat.exp_cipher);
 
-        let (cipher, mac) = encrypt_aes128(k, nonce, aad.clone(), msg.clone());
+        let (cipher, mac) = encrypt_aes128(k, nonce, &aad, &msg);
         assert_eq!(
             exp_cipher
                 .iter()
@@ -94,7 +94,7 @@ fn kat_test() {
             mac.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>()
         );
 
-        let decrypted_msg = decrypt_aes128(k, nonce, aad, cipher, mac).unwrap();
+        let decrypted_msg = decrypt_aes128(k, nonce, &aad, &cipher, mac).unwrap();
         assert_eq!(
             msg.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>(),
             decrypted_msg
@@ -114,7 +114,7 @@ fn kat_test_256() {
         let aad = ByteSeq::from_hex(kat.aad);
         let exp_cipher = ByteSeq::from_hex(kat.exp_cipher);
 
-        let (cipher, mac) = encrypt_aes256(k, nonce, aad.clone(), msg.clone());
+        let (cipher, mac) = encrypt_aes256(k, nonce, &aad, &msg);
         assert_eq!(
             exp_cipher
                 .iter()
@@ -133,7 +133,7 @@ fn kat_test_256() {
             mac.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>()
         );
 
-        let decrypted_msg = decrypt_aes256(k, nonce, aad, cipher, mac).unwrap();
+        let decrypted_msg = decrypt_aes256(k, nonce, &aad, &cipher, mac).unwrap();
         assert_eq!(
             msg.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>(),
             decrypted_msg

--- a/spec-examples/tests/test_blake2b.rs
+++ b/spec-examples/tests/test_blake2b.rs
@@ -12,7 +12,7 @@ static EXPECTED_ABC: [u8; 64] = [
 #[test]
 fn test_single_block() {
     let m = ByteSeq::from_slice(&[U8(0x61), U8(0x62), U8(0x63)]);
-    let h = blake2b(m);
+    let h = blake2b(&m);
     assert_eq!(
         EXPECTED_ABC.iter().map(|x| *x).collect::<Vec<_>>(),
         h.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>()
@@ -22,7 +22,7 @@ fn test_single_block() {
 #[test]
 fn test_single_block_string() {
     let m = String::from("abc");
-    let h = blake2b(ByteSeq::from_slice(
+    let h = blake2b(&ByteSeq::from_slice(
         &m.into_bytes()
             .iter()
             .map(|x| U8::classify(*x))
@@ -37,7 +37,7 @@ fn test_single_block_string() {
 #[test]
 fn test_multi_block_string() {
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
-    let h = blake2b(ByteSeq::from_slice(
+    let h = blake2b(&ByteSeq::from_slice(
         &m.into_bytes()
             .iter()
             .map(|x| U8::classify(*x))
@@ -60,7 +60,7 @@ fn test_multi_block_string() {
 #[test]
 fn test_multi_block_string_longer() {
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
-    let h = blake2b(ByteSeq::from_slice(
+    let h = blake2b(&ByteSeq::from_slice(
         &m.into_bytes()
             .iter()
             .map(|x| U8::classify(*x))

--- a/spec-examples/tests/test_chacha20.rs
+++ b/spec-examples/tests/test_chacha20.rs
@@ -94,8 +94,8 @@ fn test_block() {
 }
 
 fn enc_dec_test(m: ByteSeq, key: Key, iv: IV) {
-    let c = chacha(key, iv, m.clone()).unwrap();
-    let m_dec = chacha(key, iv, c).unwrap();
+    let c = chacha(key, iv, &m).unwrap();
+    let m_dec = chacha(key, iv, &c).unwrap();
     assert_eq!(
         m.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>(),
         m_dec.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>()
@@ -103,7 +103,7 @@ fn enc_dec_test(m: ByteSeq, key: Key, iv: IV) {
 }
 
 fn kat_test(m: ByteSeq, key: Key, iv: IV, exp_cipher: ByteSeq, valid: bool) {
-    let enc = chacha(key, iv, m.clone());
+    let enc = chacha(key, iv, &m);
     assert!(enc.is_ok() == valid);
     if !valid {
         return;
@@ -116,7 +116,7 @@ fn kat_test(m: ByteSeq, key: Key, iv: IV, exp_cipher: ByteSeq, valid: bool) {
             .collect::<Vec<_>>(),
         c.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>()
     );
-    let m_dec = chacha(key, iv, c).unwrap();
+    let m_dec = chacha(key, iv, &c).unwrap();
     assert_eq!(
         m.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>(),
         m_dec.iter().map(|x| U8::declassify(*x)).collect::<Vec<_>>()

--- a/spec-examples/tests/test_chacha20poly1305.rs
+++ b/spec-examples/tests/test_chacha20poly1305.rs
@@ -38,10 +38,10 @@ fn kat() {
         0x1a, 0xe1, 0x0b, 0x59, 0x4f, 0x09, 0xe2, 0x6a, 0x7e, 0x90, 0x2e, 0xcb, 0xd0, 0x60, 0x06,
         0x91
     ]);
-    let (cipher, mac) = encrypt(k, iv, aad.clone(), msg.clone()).unwrap();
+    let (cipher, mac) = encrypt(k, iv, &aad, &msg).unwrap();
     assert_bytes_eq!(exp_cipher, cipher);
     assert_eq!(exp_mac, mac);
-    let decrypted_msg = decrypt(k, iv, aad, cipher, mac).unwrap();
+    let decrypted_msg = decrypt(k, iv, &aad, &cipher, mac).unwrap();
     assert_bytes_eq!(msg, decrypted_msg);
 }
 

--- a/spec-examples/tests/test_fips202.rs
+++ b/spec-examples/tests/test_fips202.rs
@@ -5,7 +5,7 @@ use hacspec_examples::fips202::*;
 #[test]
 fn test_sha3224() {
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
-    let h = sha3224(ByteSeq::from_slice(
+    let h = sha3224(&ByteSeq::from_slice(
         &m.into_bytes()
             .iter()
             .map(|x| U8::classify(*x))
@@ -21,7 +21,7 @@ fn test_sha3224() {
     );
 
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
-    let h = sha3224(ByteSeq::from_slice(
+    let h = sha3224(&ByteSeq::from_slice(
         &m.into_bytes()
             .iter()
             .map(|x| U8::classify(*x))
@@ -40,7 +40,7 @@ fn test_sha3224() {
 #[test]
 fn test_sha3256() {
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
-    let h = sha3256(ByteSeq::from_slice(
+    let h = sha3256(&ByteSeq::from_slice(
         &m.into_bytes()
             .iter()
             .map(|x| U8::classify(*x))
@@ -57,7 +57,7 @@ fn test_sha3256() {
     );
 
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
-    let h = sha3256(ByteSeq::from_slice(
+    let h = sha3256(&ByteSeq::from_slice(
         &m.into_bytes()
             .iter()
             .map(|x| U8::classify(*x))
@@ -77,7 +77,7 @@ fn test_sha3256() {
 #[test]
 fn test_sha3384() {
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
-    let h = sha3384(ByteSeq::from_slice(
+    let h = sha3384(&ByteSeq::from_slice(
         &m.into_bytes()
             .iter()
             .map(|x| U8::classify(*x))
@@ -95,7 +95,7 @@ fn test_sha3384() {
     );
 
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
-    let h = sha3384(ByteSeq::from_slice(
+    let h = sha3384(&ByteSeq::from_slice(
         &m.into_bytes()
             .iter()
             .map(|x| U8::classify(*x))
@@ -116,7 +116,7 @@ fn test_sha3384() {
 #[test]
 fn test_sha3512() {
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
-    let h = sha3512(ByteSeq::from_slice(
+    let h = sha3512(&ByteSeq::from_slice(
         &m.into_bytes()
             .iter()
             .map(|x| U8::classify(*x))
@@ -135,7 +135,7 @@ fn test_sha3512() {
     );
 
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
-    let h = sha3512(ByteSeq::from_slice(
+    let h = sha3512(&ByteSeq::from_slice(
         &m.into_bytes()
             .iter()
             .map(|x| U8::classify(*x))
@@ -158,7 +158,7 @@ fn test_sha3512() {
 fn test_shake128() {
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
     let h = shake128(
-        ByteSeq::from_slice(
+        &ByteSeq::from_slice(
             &m.into_bytes()
                 .iter()
                 .map(|x| U8::classify(*x))
@@ -187,7 +187,7 @@ fn test_shake128() {
 
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
     let h = shake128(
-        ByteSeq::from_slice(
+        &ByteSeq::from_slice(
             &m.into_bytes()
                 .iter()
                 .map(|x| U8::classify(*x))
@@ -231,7 +231,7 @@ fn test_shake128() {
 
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
     let h = shake128(
-        ByteSeq::from_slice(
+        &ByteSeq::from_slice(
             &m.into_bytes()
                 .iter()
                 .map(|x| U8::classify(*x))
@@ -260,7 +260,7 @@ fn test_shake128() {
 
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
     let h = shake128(
-        ByteSeq::from_slice(
+        &ByteSeq::from_slice(
             &m.into_bytes()
                 .iter()
                 .map(|x| U8::classify(*x))
@@ -307,7 +307,7 @@ fn test_shake128() {
 fn test_shake256() {
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
     let h = shake256(
-        ByteSeq::from_slice(
+        &ByteSeq::from_slice(
             &m.into_bytes()
                 .iter()
                 .map(|x| U8::classify(*x))
@@ -334,7 +334,7 @@ fn test_shake256() {
 
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
     let h = shake256(
-        ByteSeq::from_slice(
+        &ByteSeq::from_slice(
             &m.into_bytes()
                 .iter()
                 .map(|x| U8::classify(*x))
@@ -378,7 +378,7 @@ fn test_shake256() {
 
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
     let h = shake256(
-        ByteSeq::from_slice(
+        &ByteSeq::from_slice(
             &m.into_bytes()
                 .iter()
                 .map(|x| U8::classify(*x))
@@ -405,7 +405,7 @@ fn test_shake256() {
 
     let m = String::from("qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789qwertzuiopasdfghjklyxcvbnm123456789");
     let h = shake256(
-        ByteSeq::from_slice(
+        &ByteSeq::from_slice(
             &m.into_bytes()
                 .iter()
                 .map(|x| U8::classify(*x))

--- a/spec-examples/tests/test_gf128.rs
+++ b/spec-examples/tests/test_gf128.rs
@@ -7,6 +7,6 @@ fn test_gmac() {
     let msg = ByteSeq::from_hex("feedfacedeadbeeffeedfacedeadbeefabaddad20000000000000000000000005a8def2f0c9e53f1f75d7853659e2a20eeb2b22aafde6419a058ab4f6f746bf40fc0c3b780f244452da3ebf1c5d82cdea2418997200ef82e44ae7e3f");
     let key = Key::from_hex("acbef20579b4b8ebce889bac8732dad7");
     let output = Tag::from_hex("cc9ae9175729a649936e890bd971a8bf");
-    let tag = gmac(msg, key);
+    let tag = gmac(&msg, key);
     assert!(output.declassify_eq(tag));
 }

--- a/spec-examples/tests/test_gf128.rs
+++ b/spec-examples/tests/test_gf128.rs
@@ -8,5 +8,5 @@ fn test_gmac() {
     let key = Key::from_hex("acbef20579b4b8ebce889bac8732dad7");
     let output = Tag::from_hex("cc9ae9175729a649936e890bd971a8bf");
     let tag = gmac(&msg, key);
-    assert!(output.declassify_eq(tag));
+    assert!(output.declassify_eq(&tag));
 }

--- a/spec-examples/tests/test_hkdf.rs
+++ b/spec-examples/tests/test_hkdf.rs
@@ -42,10 +42,10 @@ const HKDF_KAT: [HKDFTestVectors; 3] = [
 #[test]
 fn test_kat() {
     for kat in HKDF_KAT.iter() {
-        let prk = extract(ByteSeq::from_hex(kat.salt), ByteSeq::from_hex(kat.ikm));
+        let prk = extract(&ByteSeq::from_hex(kat.salt), &ByteSeq::from_hex(kat.ikm));
         assert_eq!(kat.prk, prk.to_hex());
 
-        let okm = expand(ByteSeq::from_seq(prk), ByteSeq::from_hex(kat.info), kat.l);
+        let okm = expand(&ByteSeq::from_seq(&prk), &ByteSeq::from_hex(kat.info), kat.l);
         assert_eq!(kat.okm, okm.to_hex());
     }
 }

--- a/spec-examples/tests/test_hmac.rs
+++ b/spec-examples/tests/test_hmac.rs
@@ -40,7 +40,7 @@ const HMAC_KAT: [HMACTestVectors; 5] = [
 #[test]
 fn test_hmac_kat() {
     for kat in HMAC_KAT.iter() {
-        let hmac = hmac(ByteSeq::from_hex(kat.key), ByteSeq::from_hex(kat.txt));
+        let hmac = hmac(&ByteSeq::from_hex(kat.key), &ByteSeq::from_hex(kat.txt));
         assert_eq!(kat.expected, hmac.to_hex());
     }
 }

--- a/spec-examples/tests/test_poly1305.rs
+++ b/spec-examples/tests/test_poly1305.rs
@@ -8,7 +8,7 @@ fn basic_test() {
     let key = Key::random();
     let iv = IV::random();
     let m = ByteSeq::random(40);
-    poly_mac(m, key, iv);
+    poly_mac(&m, key, iv);
 
     // RFC 7539 Test Vectors
     let msg = ByteSeq::from_public_slice(&[
@@ -25,6 +25,6 @@ fn basic_test() {
         0xa8, 0x06, 0x1d, 0xc1, 0x30, 0x51, 0x36, 0xc6, 0xc2, 0x2b, 0x8b, 0xaf, 0x0c, 0x01, 0x27,
         0xa9
     ]);
-    let computed = poly(msg, k);
+    let computed = poly(&msg, k);
     assert_eq!(expected, computed)
 }

--- a/spec-examples/tests/test_sha2.rs
+++ b/spec-examples/tests/test_sha2.rs
@@ -6,14 +6,14 @@ use hacspec_examples::sha2::hash;
 fn test_sha256_kat() {
     let msg = ByteSeq::from_hex("686163737065632072756c6573");
     let expected_256 = "b37db5ed72c97da3b2579537afbc3261ed3d5a56f57b3d8e5c1019ae35929964";
-    let digest = hash(msg);
+    let digest = hash(&msg);
     println!("{:?}", expected_256);
     println!("{:x?}", digest);
     assert_eq!(expected_256, digest.to_hex());
 
     let msg = ByteSeq::from_hex("6861637370656320697320612070726f706f73616c20666f722061206e65772073706563696669636174696f6e206c616e677561676520666f722063727970746f207072696d69746976657320746861742069732073756363696e63742c2074686174206973206561737920746f207265616420616e6420696d706c656d656e742c20616e642074686174206c656e647320697473656c6620746f20666f726d616c20766572696669636174696f6e2e");
     let expected_256 = "348ef044446d56e05210361af5a258588ad31765f446bf4cb3b67125a187a64a";
-    let digest = hash(msg);
+    let digest = hash(&msg);
     println!("{:?}", expected_256);
     println!("{:x?}", digest);
     assert_eq!(expected_256, digest.to_hex());


### PR DESCRIPTION
This function introduces (or rather officializes) a new feature in the hacspec language : immutable borrows for function arguments. Two advantages to this addition.

## Removing all clones

Since we can now have `msg: &ByteSeq` arguments to functions, we no longer have all the `.clone()` problems. An immutable borrow on an argument basically acts like a `const` qualifier.

## Formalization-compatible

By restricting the use of immutable borrows only to function arguments, `&` can be interpreted as a optional label to hacspec types and as such should not hinder too much the formalization. In terms of linear logic, applying `&` to a linear term is equivalent to promoting it to the duplicable context.