### PR TITLE
AES-GCM now generic

### DIFF
--- a/spec-examples/src/aes_gcm/aes.rs
+++ b/spec-examples/src/aes_gcm/aes.rs
@@ -178,7 +178,8 @@ fn key_expansion_aes(key: &ByteSeq, nk: usize, nr: usize, alg: AesVariant) -> By
     let mut key_ex = ByteSeq::new(match alg {
         AesVariant::Aes128 => 176,
         AesVariant::Aes256 => 240
-    }).update_start(key);
+    });
+    key_ex = key_ex.update_start(key);
     let mut i: usize;
     let num_iters : usize = match alg {
         AesVariant::Aes128 => 40,

--- a/spec-examples/src/aes_gcm/aes.rs
+++ b/spec-examples/src/aes_gcm/aes.rs
@@ -202,7 +202,7 @@ fn key_expansion_aes(key: &ByteSeq, nk: usize, nr: usize, alg: AesVariant) -> By
     key_ex
 }
 
-pub fn aes_encrypt_block(k: &ByteSeq, input: Block, nk: usize, nr: usize, alg: AesVariant) -> Block {
+pub(crate) fn aes_encrypt_block(k: &ByteSeq, input: Block, nk: usize, nr: usize, alg: AesVariant) -> Block {
     let key_ex = key_expansion_aes(k, nk, nr, alg);
     block_cipher_aes(input, key_ex, nr)
 }
@@ -219,13 +219,6 @@ pub(crate) fn aes_ctr_keyblock(k: &ByteSeq, n: Nonce, c: U32, nk: usize, nr: usi
     input = input.update(0, &n);
     input = input.update(12, &U32_to_be_bytes(c));
     aes_encrypt_block(k, input, nk, nr, alg)
-}
-
-pub(crate) fn aes128_ctr_keyblock(k: Key128, n: Nonce, c: U32, nk: usize, nr: usize) -> Block {
-    aes_ctr_keyblock(&ByteSeq::from_seq(&k), n,c, nk, nr, AesVariant::Aes128)
-}
-pub(crate) fn aes256_ctr_keyblock(k: Key256, n: Nonce, c: U32, nk: usize, nr: usize) -> Block {
-    aes_ctr_keyblock(&ByteSeq::from_seq(&k), n,c, nk, nr, AesVariant::Aes256)
 }
 
 pub(crate) fn xor_block(block: Block, keyblock: Block) -> Block {
@@ -277,25 +270,25 @@ Nk =    4  |      8
 Nr =   10  |     14
 */
 
-fn nk(alg: AesVariant) -> usize {
+pub(crate) fn nk(alg: AesVariant) -> usize {
     match alg {
         AesVariant::Aes128 => 4,
         AesVariant::Aes256 => 8
     }
 }
 
-fn nr(alg: AesVariant) -> usize {
+pub(crate) fn nr(alg: AesVariant) -> usize {
     match alg {
         AesVariant::Aes128 => 10,
         AesVariant::Aes256 => 14
     }
 }
 
-fn aes_encrypt(key: &ByteSeq, nonce: Nonce, counter: U32, msg: &ByteSeq, alg: AesVariant) -> ByteSeq {
+pub(crate) fn aes_encrypt(key: &ByteSeq, nonce: Nonce, counter: U32, msg: &ByteSeq, alg: AesVariant) -> ByteSeq {
     aes_counter_mode(key, nonce, counter, msg, nk(alg), nr(alg), alg)
 }
 
-fn aes_decrypt(key: &ByteSeq, nonce: Nonce, counter: U32, ctxt: &ByteSeq, alg: AesVariant) -> ByteSeq {
+pub(crate) fn aes_decrypt(key: &ByteSeq, nonce: Nonce, counter: U32, ctxt: &ByteSeq, alg: AesVariant) -> ByteSeq {
     aes_counter_mode(key, nonce, counter, ctxt, nk(alg), nr(alg), alg)
 }
 

--- a/spec-examples/src/aes_gcm/aes.rs
+++ b/spec-examples/src/aes_gcm/aes.rs
@@ -116,7 +116,7 @@ fn aes_enc_last(state: Block, round_key: RoundKey) -> Block {
     add_round_key(state, round_key)
 }
 
-fn rounds_aes128(state: Block, key: Bytes144) -> Block {
+fn rounds_aes(state: Block, key: ByteSeq) -> Block {
     let mut out = state;
     for i in 0..key.num_chunks(BLOCKSIZE) {
         let (_, key_block) = key.get_chunk(BLOCKSIZE, i);
@@ -124,29 +124,13 @@ fn rounds_aes128(state: Block, key: Bytes144) -> Block {
     }
     out
 }
-fn rounds_aes256(state: Block, key: Bytes208) -> Block {
-    let mut out = state;
-    for i in 0..key.num_chunks(BLOCKSIZE) {
-        let (_, key_block)  = key.get_chunk(BLOCKSIZE, i);
-        out = aes_enc(out, RoundKey::from_seq(&key_block));
-    }
-    out
-}
 
-fn block_cipher_aes128(input: Block, key: Bytes176, nr: usize) -> Block {
+fn block_cipher_aes(input : Block, key: ByteSeq, nr: usize) -> Block {
     let k0 = RoundKey::from_sub_range(&key, 0..16);
-    let k = Bytes144::from_sub_range(&key, 16..nr * 16);
+    let k = ByteSeq::from_sub_range(&key, 16..nr * 16);
     let kn = RoundKey::from_sub(&key, nr * 16, 16);
     let state = add_round_key(input, k0);
-    let state = rounds_aes128(state, k);
-    aes_enc_last(state, kn)
-}
-fn block_cipher_aes256(input: Block, key: Bytes240, nr: usize) -> Block {
-    let k0 = RoundKey::from_sub_range(&key, 0..16);
-    let k = Bytes208::from_sub_range(&key, 16..nr * 16);
-    let kn = RoundKey::from_sub(&key, nr * 16, 16);
-    let state = add_round_key(input, k0);
-    let state = rounds_aes256(state, k);
+    let state = rounds_aes(state, k);
     aes_enc_last(state, kn)
 }
 
@@ -184,29 +168,30 @@ fn key_expansion_word(w0: Word, w1: Word, i: usize, nk: usize, nr: usize) -> Wor
     k
 }
 
-fn key_expansion_aes128(key: Key128, nk: usize, nr: usize) -> Bytes176 {
-    let mut key_ex = Bytes176::new().update_start(&key);
-    let mut i: usize;
-    for j in 0..40 {
-        i = j + 4;
-        let word = key_expansion_word(
-            Word::from_sub(&key_ex, 4 * i - 16, 4),
-            Word::from_sub(&key_ex, nk * i - 4, 4),
-            i,
-            nk,
-            nr,
-        );
-        key_ex = key_ex.update(4 * i, &word);
-    }
-    key_ex
+#[derive(Clone, Copy)]
+pub enum AesVariant {
+    Aes128,
+    Aes256
 }
-fn key_expansion_aes256(key: Key256, nk: usize, nr: usize) -> Bytes240 {
-    let mut key_ex = Bytes240::new().update_start(&key);
+
+fn key_expansion_aes(key: &ByteSeq, nk: usize, nr: usize, alg: AesVariant) -> ByteSeq {
+    let mut key_ex = ByteSeq::new(match alg {
+        AesVariant::Aes128 => 176,
+        AesVariant::Aes256 => 240
+    }).update_start(key);
     let mut i: usize;
-    for j in 0..52 {
-        i = j + 8;
+    let num_iters : usize = match alg {
+        AesVariant::Aes128 => 40,
+        AesVariant::Aes256 => 52
+    };
+    let word_size = match alg {
+        AesVariant::Aes128 => 4,
+        AesVariant::Aes256 => 8
+    };
+    for j in 0..num_iters {
+        i = j + word_size;
         let word = key_expansion_word(
-            Word::from_sub(&key_ex, 4 * i - 32, 4),
+            Word::from_sub(&key_ex, 4 * (i -  word_size), 4),
             Word::from_sub(&key_ex, 4 * i - 4, 4),
             i,
             nk,
@@ -217,26 +202,30 @@ fn key_expansion_aes256(key: Key256, nk: usize, nr: usize) -> Bytes240 {
     key_ex
 }
 
+pub fn aes_encrypt_block(k: &ByteSeq, input: Block, nk: usize, nr: usize, alg: AesVariant) -> Block {
+    let key_ex = key_expansion_aes(k, nk, nr, alg);
+    block_cipher_aes(input, key_ex, nr)
+}
+
 pub fn aes128_encrypt_block(k: Key128, input: Block, nk: usize, nr: usize) -> Block {
-    let key_ex = key_expansion_aes128(k, nk, nr);
-    block_cipher_aes128(input, key_ex, nr)
+    aes_encrypt_block(&ByteSeq::from_seq(&k), input, nk, nr, AesVariant::Aes128)
 }
 pub fn aes256_encrypt_block(k: Key256, input: Block, nk: usize, nr: usize) -> Block {
-    let key_ex = key_expansion_aes256(k, nk, nr);
-    block_cipher_aes256(input, key_ex, nr)
+    aes_encrypt_block(&ByteSeq::from_seq(&k), input, nk, nr, AesVariant::Aes256)
+}
+
+pub(crate) fn aes_ctr_keyblock(k: &ByteSeq, n: Nonce, c: U32, nk: usize, nr: usize, alg: AesVariant) -> Block {
+    let mut input = Block::new();
+    input = input.update(0, &n);
+    input = input.update(12, &U32_to_be_bytes(c));
+    aes_encrypt_block(k, input, nk, nr, alg)
 }
 
 pub(crate) fn aes128_ctr_keyblock(k: Key128, n: Nonce, c: U32, nk: usize, nr: usize) -> Block {
-    let mut input = Block::new();
-    input = input.update(0, &n);
-    input = input.update(12, &U32_to_be_bytes(c));
-    aes128_encrypt_block(k, input, nk, nr)
+    aes_ctr_keyblock(&ByteSeq::from_seq(&k), n,c, nk, nr, AesVariant::Aes128)
 }
 pub(crate) fn aes256_ctr_keyblock(k: Key256, n: Nonce, c: U32, nk: usize, nr: usize) -> Block {
-    let mut input = Block::new();
-    input = input.update(0, &n);
-    input = input.update(12, &U32_to_be_bytes(c));
-    aes256_encrypt_block(k, input, nk, nr)
+    aes_ctr_keyblock(&ByteSeq::from_seq(&k), n,c, nk, nr, AesVariant::Aes256)
 }
 
 pub(crate) fn xor_block(block: Block, keyblock: Block) -> Block {
@@ -247,20 +236,21 @@ pub(crate) fn xor_block(block: Block, keyblock: Block) -> Block {
     out
 }
 
-fn aes128_counter_mode(
-    key: Key128,
+fn aes_counter_mode(
+    key: &ByteSeq,
     nonce: Nonce,
     counter: U32,
     msg: &ByteSeq,
     nk: usize,
     nr: usize,
+    alg: AesVariant
 ) -> ByteSeq {
     let mut ctr = counter;
     let mut blocks_out = ByteSeq::new(msg.len());
     for i in 0..msg.num_chunks(BLOCKSIZE) {
         let (block_len, msg_block) = msg.get_chunk(BLOCKSIZE, i);
+        let key_block = aes_ctr_keyblock(key, nonce, ctr, nk, nr, alg);
         if msg_block.len() == BLOCKSIZE {
-            let key_block = aes128_ctr_keyblock(key, nonce, ctr, nk, nr);
             blocks_out = blocks_out.set_chunk(
                 BLOCKSIZE,
                 i,
@@ -269,46 +259,11 @@ fn aes128_counter_mode(
             ctr += U32(1);
         } else {
             // Last block that needs padding
-            let keyblock = aes128_ctr_keyblock(key, nonce, ctr, nk, nr);
             let last_block = Block::new().update_start(&msg_block);
             blocks_out = blocks_out.set_chunk(
                 BLOCKSIZE,
                 i,
-                &xor_block(last_block, keyblock).subr(0..block_len),
-            );
-        }
-    }
-    blocks_out
-}
-fn aes256_counter_mode(
-    key: Key256,
-    nonce: Nonce,
-    counter: U32,
-    msg: &ByteSeq,
-    nk: usize,
-    nr: usize,
-) -> ByteSeq {
-    let mut ctr = counter;
-    let mut blocks_out = ByteSeq::new(msg.len());
-    for i in 0..msg.num_chunks(BLOCKSIZE) {
-        let (block_len, msg_block) = msg.get_chunk(BLOCKSIZE, i);
-        if msg_block.len() == BLOCKSIZE {
-            let key_block = aes256_ctr_keyblock(key, nonce, ctr, nk, nr);
-            blocks_out = blocks_out.set_chunk(
-                BLOCKSIZE,
-                i,
-                &xor_block(Block::from_seq(&msg_block), key_block),
-            );
-            ctr += U32(1);
-        } else {
-            // Last block that needs padding
-            let keyblock = aes256_ctr_keyblock(key, nonce, ctr, nk, nr);
-            let last_block = Block::new();
-            let last_block = last_block.update_start(&msg_block);
-            blocks_out = blocks_out.set_chunk(
-                BLOCKSIZE,
-                i,
-                &xor_block(last_block, keyblock).subr(0..block_len),
+                &xor_block(last_block, key_block).subr(0..block_len),
             );
         }
     }
@@ -319,20 +274,43 @@ fn aes256_counter_mode(
     >> nr := number of rounds
     AES128 | AES256
 Nk =    4  |      8
-Nr =    8  |     14
+Nr =   10  |     14
 */
+
+fn nk(alg: AesVariant) -> usize {
+    match alg {
+        AesVariant::Aes128 => 4,
+        AesVariant::Aes256 => 8
+    }
+}
+
+fn nr(alg: AesVariant) -> usize {
+    match alg {
+        AesVariant::Aes128 => 10,
+        AesVariant::Aes256 => 14
+    }
+}
+
+fn aes_encrypt(key: &ByteSeq, nonce: Nonce, counter: U32, msg: &ByteSeq, alg: AesVariant) -> ByteSeq {
+    aes_counter_mode(key, nonce, counter, msg, nk(alg), nr(alg), alg)
+}
+
+fn aes_decrypt(key: &ByteSeq, nonce: Nonce, counter: U32, ctxt: &ByteSeq, alg: AesVariant) -> ByteSeq {
+    aes_counter_mode(key, nonce, counter, ctxt, nk(alg), nr(alg), alg)
+}
+
 pub fn aes128_encrypt(key: Key128, nonce: Nonce, counter: U32, msg: &ByteSeq) -> ByteSeq {
-    aes128_counter_mode(key, nonce, counter, msg, 4, 10)
+    aes_encrypt(&ByteSeq::from_seq(&key), nonce, counter, msg, AesVariant::Aes128)
 }
 pub fn aes128_decrypt(key: Key128, nonce: Nonce, counter: U32, ctxt: &ByteSeq) -> ByteSeq {
-    aes128_counter_mode(key, nonce, counter, ctxt, 4, 10)
+    aes_decrypt(&ByteSeq::from_seq(&key), nonce, counter, ctxt, AesVariant::Aes128)
 }
 
 pub fn aes256_encrypt(key: Key256, nonce: Nonce, counter: U32, msg: &ByteSeq) -> ByteSeq {
-    aes256_counter_mode(key, nonce, counter, msg, 8, 14)
+    aes_encrypt(&ByteSeq::from_seq(&key), nonce, counter, msg, AesVariant::Aes256)
 }
 pub fn aes256_decrypt(key: Key256, nonce: Nonce, counter: U32, ctxt: &ByteSeq) -> ByteSeq {
-    aes256_counter_mode(key, nonce, counter, ctxt, 8, 14)
+    aes_decrypt(&ByteSeq::from_seq(&key), nonce, counter, ctxt, AesVariant::Aes256)
 }
 
 // Testing some internal functions.

--- a/spec-examples/src/aes_gcm/aesgcm.rs
+++ b/spec-examples/src/aes_gcm/aesgcm.rs
@@ -3,8 +3,7 @@ use hacspec::prelude::*;
 
 // Import aes and gcm
 use super::aes::{
-    self, aes128_ctr_keyblock, aes128_decrypt, aes128_encrypt, aes256_ctr_keyblock, aes256_decrypt,
-    aes256_encrypt, Block,
+    self, aes_ctr_keyblock, aes_encrypt, Block
 };
 
 use super::gf128::{gmac, Key, Tag};
@@ -36,23 +35,33 @@ fn pad_aad_msg(aad: &ByteSeq, msg: &ByteSeq) -> ByteSeq {
     padded_msg
 }
 
+pub(crate) fn encrypt_aes(
+    key: &ByteSeq,
+    iv: aes::Nonce,
+    aad: &ByteSeq,
+    msg: &ByteSeq,
+    alg: aes::AesVariant,
+) -> (ByteSeq, Tag) {
+    let iv0 = aes::Nonce::new();
+
+    let mac_key = aes_ctr_keyblock(key, iv0, U32(0), aes::nk(alg), aes::nr(alg), alg);
+    let tag_mix = aes_ctr_keyblock(key, iv, U32(1), aes::nk(alg), aes::nr(alg), alg);
+
+    let cipher_text = aes_encrypt(key, iv, U32(2), msg, alg);
+    let padded_msg = pad_aad_msg(aad, &cipher_text);
+    let tag = gmac(&padded_msg, Key::from_seq(&mac_key));
+    let tag = aes::xor_block(Block::from_seq(&tag), tag_mix);
+
+    (cipher_text, Tag::from_seq(&tag))
+}
+
 pub fn encrypt_aes128(
     key: aes::Key128,
     iv: aes::Nonce,
     aad: &ByteSeq,
     msg: &ByteSeq,
 ) -> (ByteSeq, Tag) {
-    let iv0 = aes::Nonce::new();
-
-    let mac_key = aes128_ctr_keyblock(key, iv0, U32(0), 4, 10);
-    let tag_mix = aes128_ctr_keyblock(key, iv, U32(1), 4, 10);
-
-    let cipher_text = aes128_encrypt(key, iv, U32(2), msg);
-    let padded_msg = pad_aad_msg(aad, &cipher_text);
-    let tag = gmac(&padded_msg, Key::from_seq(&mac_key));
-    let tag = aes::xor_block(Block::from_seq(&tag), tag_mix);
-
-    (cipher_text, Tag::from_seq(&tag))
+    encrypt_aes(&ByteSeq::from_seq(&key), iv, aad, msg, aes::AesVariant::Aes128)
 }
 
 pub fn encrypt_aes256(
@@ -61,17 +70,31 @@ pub fn encrypt_aes256(
     aad: &ByteSeq,
     msg: &ByteSeq,
 ) -> (ByteSeq, Tag) {
+    encrypt_aes(&ByteSeq::from_seq(&key), iv, aad, msg, aes::AesVariant::Aes256)
+}
+
+pub(crate) fn decrypt_aes(
+    key: &ByteSeq,
+    iv: aes::Nonce,
+    aad: &ByteSeq,
+    cipher_text: &ByteSeq,
+    tag: Tag,
+    alg: aes::AesVariant,
+) -> Result<ByteSeq, String> {
     let iv0 = aes::Nonce::new();
 
-    let mac_key = aes256_ctr_keyblock(key, iv0, U32(0), 8, 14);
-    let tag_mix = aes256_ctr_keyblock(key, iv, U32(1), 8, 14);
+    let mac_key = aes_ctr_keyblock(key, iv0, U32(0), aes::nk(alg), aes::nr(alg), alg);
+    let tag_mix = aes_ctr_keyblock(key, iv, U32(1), aes::nk(alg), aes::nr(alg), alg);
 
-    let cipher_text = aes256_encrypt(key, iv, U32(2), msg);
-    let padded_msg = pad_aad_msg(aad, &cipher_text);
-    let tag = gmac(&padded_msg, Key::from_seq(&mac_key));
-    let tag = aes::xor_block(Block::from_seq(&tag), tag_mix);
+    let padded_msg = pad_aad_msg(aad, cipher_text);
+    let my_tag = gmac(&padded_msg, Key::from_seq(&mac_key));
+    let my_tag = aes::xor_block(Block::from_seq(&my_tag), tag_mix);
 
-    (cipher_text, Tag::from_seq(&tag))
+    if my_tag.declassify_eq(&Block::from_seq(&tag)) {
+        Ok(aes::aes_decrypt(key, iv, U32(2), cipher_text, alg))
+    } else {
+        Err("Mac verification failed".to_string())
+    }
 }
 
 pub fn decrypt_aes128(
@@ -81,20 +104,7 @@ pub fn decrypt_aes128(
     cipher_text: &ByteSeq,
     tag: Tag,
 ) -> Result<ByteSeq, String> {
-    let iv0 = aes::Nonce::new();
-
-    let mac_key = aes128_ctr_keyblock(key, iv0, U32(0), 4, 10);
-    let tag_mix = aes128_ctr_keyblock(key, iv, U32(1), 4, 10);
-
-    let padded_msg = pad_aad_msg(aad, cipher_text);
-    let my_tag = gmac(&padded_msg, Key::from_seq(&mac_key));
-    let my_tag = aes::xor_block(Block::from_seq(&my_tag), tag_mix);
-
-    if my_tag.declassify_eq(&Block::from_seq(&tag)) {
-        Ok(aes128_decrypt(key, iv, U32(2), cipher_text))
-    } else {
-        Err("Mac verification failed".to_string())
-    }
+    decrypt_aes(&ByteSeq::from_seq(&key), iv, aad, cipher_text, tag, aes::AesVariant::Aes128)
 }
 
 pub fn decrypt_aes256(
@@ -104,18 +114,5 @@ pub fn decrypt_aes256(
     cipher_text: &ByteSeq,
     tag: Tag,
 ) -> Result<ByteSeq, String> {
-    let iv0 = aes::Nonce::new();
-
-    let mac_key = aes256_ctr_keyblock(key, iv0, U32(0), 8, 14);
-    let tag_mix = aes256_ctr_keyblock(key, iv, U32(1), 8, 14);
-
-    let padded_msg = pad_aad_msg(aad, cipher_text);
-    let my_tag = gmac(&padded_msg, Key::from_seq(&mac_key));
-    let my_tag = aes::xor_block(Block::from_seq(&my_tag), tag_mix);
-
-    if my_tag.declassify_eq(&Block::from_seq(&tag)) {
-        Ok(aes256_decrypt(key, iv, U32(2), cipher_text))
-    } else {
-        Err("Mac verification failed".to_string())
-    }
+    decrypt_aes(&ByteSeq::from_seq(&key), iv, aad, cipher_text, tag, aes::AesVariant::Aes256)
 }


### PR DESCRIPTION
With just `ByteSeq` and a `AesVariant` enum, I was able to turn the implementation of AES-GCM completely generic with respect to the 128 and 256 variants.

I'll continue with Blake2 but we can land that separately.