### PR TITLE
Added parametric arrays

### DIFF
--- a/hacspec/src/array.rs
+++ b/hacspec/src/array.rs
@@ -269,6 +269,231 @@ macro_rules! _array_base {
     };
 }
 
+
+#[macro_export]
+macro_rules! generic_array {
+    ($name:ident,$l:expr) => {
+        /// Fixed length byte array.
+        // Because Rust requires fixed length arrays to have a known size at
+        // compile time there's no generic fixed length byte array here.
+        // Use this to define the fixed length byte arrays needed in your code.
+        #[allow(non_camel_case_types)]
+        #[derive(Clone, Copy)]
+        pub struct $name<T>(pub [T; $l]);
+
+        impl<T: Numeric> $name<T> {
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            pub fn new() -> Self {
+                Self([<T>::default(); $l])
+            }
+
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            pub fn len(&self) -> usize {
+                $l
+            }
+
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            pub fn from_array(v: [T; $l]) -> Self {
+                Self(v.clone())
+            }
+
+            #[cfg_attr(feature="use_attributes", external(hacspec))]
+            pub fn from_slice(v: &[T]) -> Self {
+                debug_assert!(v.len() <= $l);
+                let mut tmp = [<T>::default(); $l];
+                for i in 0..v.len() {
+                    tmp[i] = v[i];
+                }
+                Self(tmp.clone())
+            }
+        }
+
+        impl<T: Numeric> $name<T> {
+            #[cfg_attr(feature="use_attributes", external(hacspec))]
+            pub fn capacity() -> usize {
+                $l
+            }
+
+            #[cfg_attr(feature="use_attributes", library(hacspec))]
+            pub fn from_sub<A: SeqTrait<T>>(input: &A, start: usize, len: usize) -> Self {
+                let mut a = Self::new();
+                debug_assert_eq!(len, a.len());
+                a = a.update_sub(0, input, start, len);
+                a
+            }
+
+            #[cfg_attr(feature="use_attributes", library(hacspec))]
+            pub fn from_sub_range<A: SeqTrait<T>>(input: &A, r: Range<usize>) -> Self {
+                Self::from_sub(input, r.start, r.end - r.start)
+            }
+
+            #[cfg_attr(feature="use_attributes", library(hacspec))]
+            pub fn sub(&self, start_out: usize, len: usize) -> Seq<T> {
+                Seq::from_sub(self, start_out, len)
+            }
+
+            #[cfg_attr(feature="use_attributes", library(hacspec))]
+            pub fn subr(&self, r: Range<usize>) -> Seq<T> {
+                self.sub(r.start, r.end - r.start)
+            }
+
+            #[cfg_attr(feature="use_attributes", library(hacspec))]
+            pub fn num_chunks(
+                &self,
+                chunk_size: usize
+            ) -> usize {
+                (self.len() + chunk_size - 1) / chunk_size
+            }
+
+            #[cfg_attr(feature="use_attributes", library(hacspec))]
+            pub fn get_chunk_len(
+                &self,
+                chunk_size: usize,
+                chunk_number: usize
+            ) -> usize {
+                let idx_start = chunk_size * chunk_number;
+                if idx_start + chunk_size > self.len() {
+                    self.len() - idx_start
+                } else {
+                    chunk_size
+                }
+            }
+
+            #[cfg_attr(feature="use_attributes", library(hacspec))]
+            pub fn get_chunk(
+                &self,
+                chunk_size: usize,
+                chunk_number: usize
+            ) -> (usize, Seq<T>) {
+                let idx_start = chunk_size * chunk_number;
+                let len = self.get_chunk_len(chunk_size, chunk_number);
+                let out = self.sub(idx_start, len);
+                (len, out)
+            }
+
+            #[cfg_attr(feature="use_attributes", library(hacspec))]
+            pub fn set_chunk<A: SeqTrait<T>>(
+                self,
+                chunk_size: usize,
+                chunk_number: usize,
+                input: &A,
+            ) -> Self {
+                let idx_start = chunk_size * chunk_number;
+                let len = self.get_chunk_len(chunk_size, chunk_number);
+                debug_assert!(input.len() == len, "the chunk length should match the input");
+                self.update_sub(idx_start, input, 0, len)
+            }
+        }
+
+        impl<T: Numeric> Default for $name<T> {
+            #[cfg_attr(feature="use_attributes", library(hacspec))]
+            fn default() -> Self {
+                $name::new()
+            }
+        }
+        impl<T: Numeric> SeqTrait<T> for $name<T> {
+            #[cfg_attr(feature="use_attributes", library(hacspec))]
+            fn create(x:usize) -> Self {
+                assert_eq!(x, $l);
+                Self::new()
+            }
+
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            fn len(&self) -> usize {
+                $l
+            }
+            #[cfg_attr(feature="use_attributes", external(hacspec))]
+            fn iter(&self) -> std::slice::Iter<T> {
+                self.0.iter()
+            }
+        }
+
+        impl<T: Numeric> Index<usize> for $name<T> {
+            type Output = T;
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            fn index(&self, i: usize) -> &T {
+                &self.0[i]
+            }
+        }
+        impl<T: Numeric> IndexMut<usize> for $name<T> {
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            fn index_mut(&mut self, i: usize) -> &mut T {
+                &mut self.0[i]
+            }
+        }
+
+        impl<T: Numeric> Index<u8> for $name<T> {
+            type Output = T;
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            fn index(&self, i: u8) -> &T {
+                &self.0[i as usize]
+            }
+        }
+        impl<T: Numeric> IndexMut<u8> for $name<T> {
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            fn index_mut(&mut self, i: u8) -> &mut T {
+                &mut self.0[i as usize]
+            }
+        }
+        impl<T: Numeric> Index<u32> for $name<T> {
+            type Output = T;
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            fn index(&self, i: u32) -> &T {
+                &self.0[i as usize]
+            }
+        }
+        impl<T: Numeric> IndexMut<u32> for $name<T> {
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            fn index_mut(&mut self, i: u32) -> &mut T {
+                &mut self.0[i as usize]
+            }
+        }
+        impl<T: Numeric> Index<i32> for $name<T> {
+            type Output = T;
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            fn index(&self, i: i32) -> &T {
+                &self.0[i as usize]
+            }
+        }
+        impl<T: Numeric> IndexMut<i32> for $name<T> {
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            fn index_mut(&mut self, i: i32) -> &mut T {
+                &mut self.0[i as usize]
+            }
+        }
+        impl<T: Numeric> Index<RangeFull> for $name<T> {
+            type Output = [T];
+            #[cfg_attr(feature="use_attributes", primitive(hacspec))]
+            fn index(&self, r: RangeFull) -> &[T] {
+                &self.0[r]
+            }
+        }
+        impl<T: Numeric> $name<T> {
+            #[cfg_attr(feature="use_attributes", external(hacspec))]
+            pub fn from_vec(x: Vec<T>) -> $name<T> {
+                debug_assert_eq!(x.len(), $l);
+                let mut tmp = [<T>::default(); $l];
+                for (i, e) in x.iter().enumerate() {
+                    tmp[i] = *e;
+                }
+                $name(tmp.clone())
+            }
+
+            // We can't use the [From] trait here because otherwise it would conflict with
+            // the From<T> for T core implementation, as the array also implements the [SeqTrait].
+            #[cfg_attr(feature="use_attributes", library(hacspec))]
+            pub fn from_seq<U: SeqTrait<T>>(x: &U) -> $name<T> {
+                debug_assert_eq!(x.len(), $l);
+                let mut out = $name::new();
+                for i in 0..x.len() {
+                    out[i] = x[i];
+                }
+                out
+            }
+        }
+    };
+}
+
 #[macro_export]
 /// This creates arrays for secret integers, i.e. `$t` is the secret integer
 /// type and `$tbase` is the according Rust type.

--- a/hacspec/src/array.rs
+++ b/hacspec/src/array.rs
@@ -491,6 +491,17 @@ macro_rules! generic_array {
                 out
             }
         }
+
+        /// **Warning:** declassifies secret integer types.
+        impl<T: Numeric> fmt::Debug for $name<T> {
+            #[cfg_attr(feature="use_attributes", external(hacspec))]
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0[..]
+                    .iter()
+                    .collect::<Vec<_>>()
+                    .fmt(f)
+            }
+        }
     };
 }
 

--- a/hacspec/src/lib.rs
+++ b/hacspec/src/lib.rs
@@ -41,13 +41,14 @@ bytes!(DocSecretBytes, 64);
 public_bytes!(DocPublicBytes, 64);
 array!(DocSecretArray, 64, U32);
 array!(DocPublicArray, 64, u32);
+generic_array!(DocParametricArray, 64);
 
+bytes!(U16Word, 2);
 bytes!(U32Word, 4);
-bytes!(U128Word, 16);
 bytes!(U64Word, 8);
+bytes!(U128Word, 16);
 
+public_bytes!(u16Word, 2);
 public_bytes!(u32Word, 4);
 public_bytes!(u64Word, 8);
 public_bytes!(u128Word, 16);
-
-generic_array!(ParametricArray, 64);

--- a/hacspec/src/lib.rs
+++ b/hacspec/src/lib.rs
@@ -49,3 +49,5 @@ bytes!(U64Word, 8);
 public_bytes!(u32Word, 4);
 public_bytes!(u64Word, 8);
 public_bytes!(u128Word, 16);
+
+generic_array!(ParametricArray, 64);

--- a/hacspec/src/traits.rs
+++ b/hacspec/src/traits.rs
@@ -5,10 +5,12 @@
 use crate::prelude::*;
 
 /// Common trait for all byte arrays and sequences.
-pub trait SeqTrait<T: Copy> : Index<usize, Output=T> + IndexMut<usize, Output=T> + Sized {
+pub trait SeqTrait<T: Copy>:
+    Index<usize, Output = T> + IndexMut<usize, Output = T> + Sized
+{
     fn len(&self) -> usize;
     fn iter(&self) -> std::slice::Iter<T>;
-    fn create(len:usize) -> Self;
+    fn create(len: usize) -> Self;
     /// Update this sequence with `l` elements of `v`, starting at `start_in`,
     /// at `start_out`.
     ///
@@ -49,17 +51,14 @@ pub trait SeqTrait<T: Copy> : Index<usize, Output=T> + IndexMut<usize, Output=T>
     /// s = s.update(2, &tmp);
     /// // assert_eq!(s, Seq::<u8>::from_array(&[0, 0, 2, 3, 0]));
     /// ```
-    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn update<A: SeqTrait<T>>(self, start: usize, v: &A) -> Self {
         let len = v.len();
         self.update_sub(start, v, 0, len)
     }
 
-    #[cfg_attr(feature="use_attributes", library(hacspec))]
-    fn update_start<A: SeqTrait<T>>(
-        self,
-        v: &A
-    ) -> Self {
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
+    fn update_start<A: SeqTrait<T>>(self, v: &A) -> Self {
         let len = v.len();
         self.update_sub(0, v, 0, len)
     }
@@ -100,29 +99,44 @@ pub trait Integer: Numeric {
         let b = y.get_bit(yi);
         self.set_bit(b, pos)
     }
-}
 
+    fn rotate_left(self, n: u32) -> Self {
+        // Taken from https://blog.regehr.org/archives/1063
+        assert!(n < Self::NUM_BITS);
+        (self << n) | (self >> ((-(n as i32) as u32) & (Self::NUM_BITS - 1)))
+    }
+
+    fn rotate_right(self, n: u32) -> Self {
+        // Taken from https://blog.regehr.org/archives/1063
+        assert!(n < Self::NUM_BITS);
+        (self >> n) | (self << ((-(n as i32) as u32) & (Self::NUM_BITS - 1)))
+    }
+}
 
 pub trait SecretInteger: Integer {}
 
 impl SecretInteger for U8 {}
 impl SecretInteger for U16 {}
 impl SecretInteger for U32 {}
+impl SecretInteger for U64 {}
 impl SecretInteger for U128 {}
 impl SecretInteger for I8 {}
 impl SecretInteger for I16 {}
 impl SecretInteger for I32 {}
+impl SecretInteger for I64 {}
 impl SecretInteger for I128 {}
 
-pub trait PublicInteger {}
+pub trait PublicInteger: Integer {}
 
 impl PublicInteger for u8 {}
 impl PublicInteger for u16 {}
 impl PublicInteger for u32 {}
+impl PublicInteger for u64 {}
 impl PublicInteger for u128 {}
 impl PublicInteger for i8 {}
 impl PublicInteger for i16 {}
 impl PublicInteger for i32 {}
+impl PublicInteger for i64 {}
 impl PublicInteger for i128 {}
 
 pub trait UnsignedInteger: Integer {}
@@ -130,10 +144,12 @@ pub trait UnsignedInteger: Integer {}
 impl UnsignedInteger for U8 {}
 impl UnsignedInteger for U16 {}
 impl UnsignedInteger for U32 {}
+impl UnsignedInteger for U64 {}
 impl UnsignedInteger for U128 {}
 impl UnsignedInteger for u8 {}
 impl UnsignedInteger for u16 {}
 impl UnsignedInteger for u32 {}
+impl UnsignedInteger for u64 {}
 impl UnsignedInteger for u128 {}
 
 pub trait SignedInteger: Integer {}
@@ -141,11 +157,229 @@ pub trait SignedInteger: Integer {}
 impl SignedInteger for I8 {}
 impl SignedInteger for I16 {}
 impl SignedInteger for I32 {}
+impl SignedInteger for I64 {}
 impl SignedInteger for I128 {}
 impl SignedInteger for i8 {}
 impl SignedInteger for i16 {}
 impl SignedInteger for i32 {}
+impl SignedInteger for i64 {}
 impl SignedInteger for i128 {}
+
+pub trait UnsignedSecretInteger : UnsignedInteger + SecretInteger {
+    fn to_le_bytes(self) -> Seq<U8>;
+    fn to_be_bytes(self) -> Seq<U8>;
+    fn from_le_bytes(x: &Seq<U8>) -> Self;
+    fn from_be_bytes(x: &Seq<U8>) -> Self;
+}
+
+impl UnsignedSecretInteger for U8 {
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_le_bytes(self) -> Seq<U8>{
+        let mut x = Seq::new(1);
+        x[0] = self;
+        x
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_be_bytes(self) -> Seq<U8> {
+        let mut x = Seq::new(1);
+        x[0] = self;
+        x
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_le_bytes(x: &Seq<U8>) -> Self {
+        assert!(x.len() == 1);
+        x[0]
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_be_bytes(x: &Seq<U8>) -> Self {
+        assert!(x.len() == 1);
+        x[0]
+    }
+}
+
+impl UnsignedSecretInteger for U16 {
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_le_bytes(self) -> Seq<U8> {
+        Seq::from_seq(&U16_to_le_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_be_bytes(self) -> Seq<U8> {
+        Seq::from_seq(&U16_to_be_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_le_bytes(x: &Seq<U8>) -> Self {
+        U16_from_le_bytes(U16Word::from_seq(x))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_be_bytes(x: &Seq<U8>) -> Self {
+        U16_from_be_bytes(U16Word::from_seq(x))
+    }
+}
+
+impl UnsignedSecretInteger for U32 {
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_le_bytes(self) -> Seq<U8> {
+        Seq::from_seq(&U32_to_le_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_be_bytes(self) -> Seq<U8> {
+        Seq::from_seq(&U32_to_be_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_le_bytes(x: &Seq<U8>) -> Self {
+        U32_from_le_bytes(U32Word::from_seq(x))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_be_bytes(x: &Seq<U8>) -> Self {
+        U32_from_be_bytes(U32Word::from_seq(x))
+    }
+}
+
+impl UnsignedSecretInteger for U64 {
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_le_bytes(self) -> Seq<U8> {
+        Seq::from_seq(&U64_to_le_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_be_bytes(self) -> Seq<U8> {
+        Seq::from_seq(&U64_to_be_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_le_bytes(x: &Seq<U8>) -> Self {
+        U64_from_le_bytes(U64Word::from_seq(x))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_be_bytes(x: &Seq<U8>) -> Self {
+        U64_from_be_bytes(U64Word::from_seq(x))
+    }
+}
+
+impl UnsignedSecretInteger for U128 {
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_le_bytes(self) -> Seq<U8> {
+        Seq::from_seq(&U128_to_le_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_be_bytes(self) -> Seq<U8> {
+        Seq::from_seq(&U128_to_be_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_le_bytes(x: &Seq<U8>) -> Self {
+        U128_from_le_bytes(U128Word::from_seq(x))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_be_bytes(x: &Seq<U8>) -> Self {
+        U128_from_be_bytes(U128Word::from_seq(x))
+    }
+}
+
+pub trait UnsignedPublicInteger : UnsignedInteger + PublicInteger {
+    fn to_le_bytes(self) -> Seq<u8>;
+    fn to_be_bytes(self) -> Seq<u8>;
+    fn from_le_bytes(x: &Seq<u8>) -> Self;
+    fn from_be_bytes(x: &Seq<u8>) -> Self;
+}
+
+impl UnsignedPublicInteger for u8 {
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_le_bytes(self) -> Seq<u8>{
+        let mut x = Seq::new(1);
+        x[0] = self;
+        x
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_be_bytes(self) -> Seq<u8> {
+        let mut x = Seq::new(1);
+        x[0] = self;
+        x
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_le_bytes(x: &Seq<u8>) -> Self {
+        assert!(x.len() == 1);
+        x[0]
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_be_bytes(x: &Seq<u8>) -> Self {
+        assert!(x.len() == 1);
+        x[0]
+    }
+}
+
+impl UnsignedPublicInteger for u16 {
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_le_bytes(self) -> Seq<u8> {
+        Seq::from_seq(&u16_to_le_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_be_bytes(self) -> Seq<u8> {
+        Seq::from_seq(&u16_to_be_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_le_bytes(x: &Seq<u8>) -> Self {
+        u16_from_le_bytes(u16Word::from_seq(x))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_be_bytes(x: &Seq<u8>) -> Self {
+        u16_from_be_bytes(u16Word::from_seq(x))
+    }
+}
+
+impl UnsignedPublicInteger for u32 {
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_le_bytes(self) -> Seq<u8> {
+        Seq::from_seq(&u32_to_le_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_be_bytes(self) -> Seq<u8> {
+        Seq::from_seq(&u32_to_be_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_le_bytes(x: &Seq<u8>) -> Self {
+        u32_from_le_bytes(u32Word::from_seq(x))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_be_bytes(x: &Seq<u8>) -> Self {
+        u32_from_be_bytes(u32Word::from_seq(x))
+    }
+}
+
+impl UnsignedPublicInteger for u64 {
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_le_bytes(self) -> Seq<u8> {
+        Seq::from_seq(&u64_to_le_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_be_bytes(self) -> Seq<u8> {
+        Seq::from_seq(&u64_to_be_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_le_bytes(x: &Seq<u8>) -> Self {
+        u64_from_le_bytes(u64Word::from_seq(x))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_be_bytes(x: &Seq<u8>) -> Self {
+        u64_from_be_bytes(u64Word::from_seq(x))
+    }
+}
+
+impl UnsignedPublicInteger for u128 {
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_le_bytes(self) -> Seq<u8> {
+        Seq::from_seq(&u128_to_le_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn to_be_bytes(self) -> Seq<u8> {
+        Seq::from_seq(&u128_to_be_bytes(self))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_le_bytes(x: &Seq<u8>) -> Self {
+        u128_from_le_bytes(u128Word::from_seq(x))
+    }
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
+    fn from_be_bytes(x: &Seq<u8>) -> Self {
+        u128_from_be_bytes(u128Word::from_seq(x))
+    }
+}
 
 pub trait Numeric: NumericBase + Copy {}
 

--- a/hacspec/src/traits.rs
+++ b/hacspec/src/traits.rs
@@ -8,8 +8,11 @@ use crate::prelude::*;
 pub trait SeqTrait<T: Copy>:
     Index<usize, Output = T> + IndexMut<usize, Output = T> + Sized
 {
+    #[cfg_attr(feature="use_attributes", primitive(hacspec))]
     fn len(&self) -> usize;
+    #[cfg_attr(feature="use_attributes", primitive(hacspec))]
     fn iter(&self) -> std::slice::Iter<T>;
+    #[cfg_attr(feature="use_attributes", primitive(hacspec))]
     fn create(len: usize) -> Self;
     /// Update this sequence with `l` elements of `v`, starting at `start_in`,
     /// at `start_out`.
@@ -24,6 +27,7 @@ pub trait SeqTrait<T: Copy>:
     /// s = s.update_sub(2, &tmp, 1, 1);
     /// // assert_eq!(s, Seq::<u8>::from_array(&[0, 0, 3, 0, 0]));
     /// ```
+    #[cfg_attr(feature="use_attributes", library(hacspec))]
     fn update_sub<A: SeqTrait<T>>(
         mut self,
         start_out: usize,
@@ -75,10 +79,12 @@ pub trait Integer: Numeric {
     const TWO: Self;
 
     /// Get an integer with value `val`.
+    #[cfg_attr(feature = "use_attributes", primitive(hacspec))]
     fn from_literal(val: u128) -> Self;
 
     /// Get bit `i` of this integer.
     #[inline]
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn get_bit(self, i: u32) -> Self {
         (self >> i) & Self::ONE
     }
@@ -86,6 +92,7 @@ pub trait Integer: Numeric {
     /// Set bit `i` of this integer to `b` and return the result.
     /// Bit `b` has to be `0` or `1`.
     #[inline]
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn set_bit(self, b: Self, i: u32) -> Self {
         debug_assert!(b.equal(Self::ONE) || b.equal(Self::ZERO));
         let tmp1 = Self::from_literal(!(1 << i));
@@ -95,17 +102,20 @@ pub trait Integer: Numeric {
 
     /// Set bit `pos` of this integer to bit `yi` of integer `y`.
     #[inline]
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn set(self, pos: u32, y: Self, yi: u32) -> Self {
         let b = y.get_bit(yi);
         self.set_bit(b, pos)
     }
 
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn rotate_left(self, n: u32) -> Self {
         // Taken from https://blog.regehr.org/archives/1063
         assert!(n < Self::NUM_BITS);
         (self << n) | (self >> ((-(n as i32) as u32) & (Self::NUM_BITS - 1)))
     }
 
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn rotate_right(self, n: u32) -> Self {
         // Taken from https://blog.regehr.org/archives/1063
         assert!(n < Self::NUM_BITS);
@@ -115,65 +125,76 @@ pub trait Integer: Numeric {
 
 pub trait SecretInteger: Integer {
     type PublicVersion : PublicInteger;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self;
 }
 
 impl SecretInteger for U8 {
     type PublicVersion = u8;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self {
         U8(x)
     }
 }
 impl SecretInteger for U16 {
     type PublicVersion = u16;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self {
         U16(x)
     }
 }
 impl SecretInteger for U32 {
     type PublicVersion = u32;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self {
         U32(x)
     }
 }
 impl SecretInteger for U64 {
     type PublicVersion = u64;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self {
         U64(x)
     }
 }
 impl SecretInteger for U128 {
     type PublicVersion = u128;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self {
         U128(x)
     }
 }
 impl SecretInteger for I8 {
     type PublicVersion = i8;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self {
         I8(x)
     }
 }
 impl SecretInteger for I16 {
     type PublicVersion = i16;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self {
         I16(x)
     }
 }
 impl SecretInteger for I32 {
     type PublicVersion = i32;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self {
         I32(x)
     }
 }
 impl SecretInteger for I64 {
     type PublicVersion = i64;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self {
         I64(x)
     }
 }
 impl SecretInteger for I128 {
     type PublicVersion = i128;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self {
         I128(x)
     }
@@ -241,12 +262,17 @@ impl SignedInteger for i64 {}
 impl SignedInteger for i128 {}
 
 pub trait UnsignedSecretInteger : UnsignedInteger + SecretInteger {
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn to_le_bytes(self) -> Seq<U8>;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn to_be_bytes(self) -> Seq<U8>;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn from_le_bytes(x: &Seq<U8>) -> Self;
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn from_be_bytes(x: &Seq<U8>) -> Self;
     /// Get byte `i` of this integer.
     #[inline]
+    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn get_byte(self, i: u32) -> Self {
         (self >> (i * 8)) & ((Self::ONE << 8) - Self::ONE)
     }

--- a/hacspec/src/traits.rs
+++ b/hacspec/src/traits.rs
@@ -113,31 +113,106 @@ pub trait Integer: Numeric {
     }
 }
 
-pub trait SecretInteger: Integer {}
+pub trait SecretInteger: Integer {
+    type PublicVersion : Integer;
+    fn classify(x: Self::PublicVersion) -> Self;
+}
 
-impl SecretInteger for U8 {}
-impl SecretInteger for U16 {}
-impl SecretInteger for U32 {}
-impl SecretInteger for U64 {}
-impl SecretInteger for U128 {}
-impl SecretInteger for I8 {}
-impl SecretInteger for I16 {}
-impl SecretInteger for I32 {}
-impl SecretInteger for I64 {}
-impl SecretInteger for I128 {}
+impl SecretInteger for U8 {
+    type PublicVersion = u8;
+    fn classify(x: Self::PublicVersion) -> Self {
+        U8(x)
+    }
+}
+impl SecretInteger for U16 {
+    type PublicVersion = u16;
+    fn classify(x: Self::PublicVersion) -> Self {
+        U16(x)
+    }
+}
+impl SecretInteger for U32 {
+    type PublicVersion = u32;
+    fn classify(x: Self::PublicVersion) -> Self {
+        U32(x)
+    }
+}
+impl SecretInteger for U64 {
+    type PublicVersion = u64;
+    fn classify(x: Self::PublicVersion) -> Self {
+        U64(x)
+    }
+}
+impl SecretInteger for U128 {
+    type PublicVersion = u128;
+    fn classify(x: Self::PublicVersion) -> Self {
+        U128(x)
+    }
+}
+impl SecretInteger for I8 {
+    type PublicVersion = i8;
+    fn classify(x: Self::PublicVersion) -> Self {
+        I8(x)
+    }
+}
+impl SecretInteger for I16 {
+    type PublicVersion = i16;
+    fn classify(x: Self::PublicVersion) -> Self {
+        I16(x)
+    }
+}
+impl SecretInteger for I32 {
+    type PublicVersion = i32;
+    fn classify(x: Self::PublicVersion) -> Self {
+        I32(x)
+    }
+}
+impl SecretInteger for I64 {
+    type PublicVersion = i64;
+    fn classify(x: Self::PublicVersion) -> Self {
+        I64(x)
+    }
+}
+impl SecretInteger for I128 {
+    type PublicVersion = i128;
+    fn classify(x: Self::PublicVersion) -> Self {
+        I128(x)
+    }
+}
 
-pub trait PublicInteger: Integer {}
+pub trait PublicInteger: Integer {
+    type SecretVersion : Integer;
+}
 
-impl PublicInteger for u8 {}
-impl PublicInteger for u16 {}
-impl PublicInteger for u32 {}
-impl PublicInteger for u64 {}
-impl PublicInteger for u128 {}
-impl PublicInteger for i8 {}
-impl PublicInteger for i16 {}
-impl PublicInteger for i32 {}
-impl PublicInteger for i64 {}
-impl PublicInteger for i128 {}
+impl PublicInteger for u8 {
+    type SecretVersion = U8;
+}
+impl PublicInteger for u16 {
+    type SecretVersion = U16;
+}
+impl PublicInteger for u32 {
+    type SecretVersion = U32;
+}
+impl PublicInteger for u64 {
+    type SecretVersion = U64;
+}
+impl PublicInteger for u128 {
+    type SecretVersion = U128;
+}
+impl PublicInteger for i8 {
+    type SecretVersion = I8;
+}
+impl PublicInteger for i16 {
+    type SecretVersion = I16;
+}
+impl PublicInteger for i32 {
+    type SecretVersion = I32;
+}
+impl PublicInteger for i64 {
+    type SecretVersion = I64;
+}
+impl PublicInteger for i128 {
+    type SecretVersion = I128;
+}
 
 pub trait UnsignedInteger: Integer {}
 
@@ -407,7 +482,7 @@ pub trait NumericBase:
     + BitAnd<Self, Output = Self>
     + Shl<u32, Output = Self>
     + Shr<u32, Output = Self>
-    + Not
+    + Not<Output = Self>
     + Default
     + Clone
     + Debug

--- a/hacspec/src/traits.rs
+++ b/hacspec/src/traits.rs
@@ -8,11 +8,8 @@ use crate::prelude::*;
 pub trait SeqTrait<T: Copy>:
     Index<usize, Output = T> + IndexMut<usize, Output = T> + Sized
 {
-    #[cfg_attr(feature="use_attributes", primitive(hacspec))]
     fn len(&self) -> usize;
-    #[cfg_attr(feature="use_attributes", primitive(hacspec))]
     fn iter(&self) -> std::slice::Iter<T>;
-    #[cfg_attr(feature="use_attributes", primitive(hacspec))]
     fn create(len: usize) -> Self;
     /// Update this sequence with `l` elements of `v`, starting at `start_in`,
     /// at `start_out`.
@@ -79,7 +76,6 @@ pub trait Integer: Numeric {
     const TWO: Self;
 
     /// Get an integer with value `val`.
-    #[cfg_attr(feature = "use_attributes", primitive(hacspec))]
     fn from_literal(val: u128) -> Self;
 
     /// Get bit `i` of this integer.
@@ -125,7 +121,6 @@ pub trait Integer: Numeric {
 
 pub trait SecretInteger: Integer {
     type PublicVersion : PublicInteger;
-    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn classify(x: Self::PublicVersion) -> Self;
 }
 
@@ -262,13 +257,9 @@ impl SignedInteger for i64 {}
 impl SignedInteger for i128 {}
 
 pub trait UnsignedSecretInteger : UnsignedInteger + SecretInteger {
-    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn to_le_bytes(self) -> Seq<U8>;
-    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn to_be_bytes(self) -> Seq<U8>;
-    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn from_le_bytes(x: &Seq<U8>) -> Self;
-    #[cfg_attr(feature = "use_attributes", library(hacspec))]
     fn from_be_bytes(x: &Seq<U8>) -> Self;
     /// Get byte `i` of this integer.
     #[inline]

--- a/hacspec/src/traits.rs
+++ b/hacspec/src/traits.rs
@@ -114,7 +114,7 @@ pub trait Integer: Numeric {
 }
 
 pub trait SecretInteger: Integer {
-    type PublicVersion : Integer;
+    type PublicVersion : PublicInteger;
     fn classify(x: Self::PublicVersion) -> Self;
 }
 
@@ -245,6 +245,11 @@ pub trait UnsignedSecretInteger : UnsignedInteger + SecretInteger {
     fn to_be_bytes(self) -> Seq<U8>;
     fn from_le_bytes(x: &Seq<U8>) -> Self;
     fn from_be_bytes(x: &Seq<U8>) -> Self;
+    /// Get byte `i` of this integer.
+    #[inline]
+    fn get_byte(self, i: u32) -> Self {
+        (self >> (i * 8)) & ((Self::ONE << 8) - Self::ONE)
+    }
 }
 
 impl UnsignedSecretInteger for U8 {

--- a/hacspec/src/transmute.rs
+++ b/hacspec/src/transmute.rs
@@ -4,6 +4,24 @@ use crate::prelude::*;
 
 // U32
 
+pub fn U16_to_le_bytes(x: U16) -> U16Word {
+    U16Word::from_vec(U16::to_le_bytes(&[x]))
+}
+
+pub fn U16_to_be_bytes(x: U16) -> U16Word {
+    U16Word::from_vec(U16::to_be_bytes(&[x]))
+}
+
+pub fn U16_from_be_bytes(s: U16Word) -> U16 {
+    U16::from_be_bytes(&s.0)[0]
+}
+
+pub fn U16_from_le_bytes(s: U16Word) -> U16 {
+    U16::from_le_bytes(&s.0)[0]
+}
+
+// U32
+
 pub fn U32_to_le_bytes(x: U32) -> U32Word {
     U32Word::from_vec(U32::to_le_bytes(&[x]))
 }
@@ -54,6 +72,24 @@ pub fn U128_from_be_bytes(s: U128Word) -> U128 {
 
 pub fn U128_from_le_bytes(s: U128Word) -> U128 {
     U128::from_le_bytes(&s.0)[0]
+}
+
+// u16
+
+pub fn u16_to_le_bytes(x: u16) -> u16Word {
+    u16Word::from_array(u16::to_le_bytes(x))
+}
+
+pub fn u16_to_be_bytes(x: u16) -> u16Word {
+    u16Word::from_array(u16::to_be_bytes(x))
+}
+
+pub fn u16_from_be_bytes(s: u16Word) -> u16 {
+    u16::from_be_bytes(s.0)
+}
+
+pub fn u16_from_le_bytes(s: u16Word) -> u16 {
+    u16::from_le_bytes(s.0)
 }
 
 // u32

--- a/hacspec/src/transmute.rs
+++ b/hacspec/src/transmute.rs
@@ -4,144 +4,176 @@ use crate::prelude::*;
 
 // U32
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U16_to_le_bytes(x: U16) -> U16Word {
     U16Word::from_vec(U16::to_le_bytes(&[x]))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U16_to_be_bytes(x: U16) -> U16Word {
     U16Word::from_vec(U16::to_be_bytes(&[x]))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U16_from_be_bytes(s: U16Word) -> U16 {
     U16::from_be_bytes(&s.0)[0]
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U16_from_le_bytes(s: U16Word) -> U16 {
     U16::from_le_bytes(&s.0)[0]
 }
 
 // U32
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U32_to_le_bytes(x: U32) -> U32Word {
     U32Word::from_vec(U32::to_le_bytes(&[x]))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U32_to_be_bytes(x: U32) -> U32Word {
     U32Word::from_vec(U32::to_be_bytes(&[x]))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U32_from_be_bytes(s: U32Word) -> U32 {
     U32::from_be_bytes(&s.0)[0]
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U32_from_le_bytes(s: U32Word) -> U32 {
     U32::from_le_bytes(&s.0)[0]
 }
 
 // U64
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U64_to_le_bytes(x: U64) -> U64Word {
     U64Word::from_vec(U64::to_le_bytes(&[x]))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U64_to_be_bytes(x: U64) -> U64Word {
     U64Word::from_vec(U64::to_be_bytes(&[x]))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U64_from_be_bytes(s: U64Word) -> U64 {
     U64::from_be_bytes(&s.0)[0]
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U64_from_le_bytes(s: U64Word) -> U64 {
     U64::from_le_bytes(&s.0)[0]
 }
 
 // U128
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U128_to_le_bytes(x: U128) -> U128Word {
     U128Word::from_vec(U128::to_le_bytes(&[x]))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U128_to_be_bytes(x: U128) -> U128Word {
     U128Word::from_vec(U128::to_be_bytes(&[x]))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U128_from_be_bytes(s: U128Word) -> U128 {
     U128::from_be_bytes(&s.0)[0]
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn U128_from_le_bytes(s: U128Word) -> U128 {
     U128::from_le_bytes(&s.0)[0]
 }
 
 // u16
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u16_to_le_bytes(x: u16) -> u16Word {
     u16Word::from_array(u16::to_le_bytes(x))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u16_to_be_bytes(x: u16) -> u16Word {
     u16Word::from_array(u16::to_be_bytes(x))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u16_from_be_bytes(s: u16Word) -> u16 {
     u16::from_be_bytes(s.0)
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u16_from_le_bytes(s: u16Word) -> u16 {
     u16::from_le_bytes(s.0)
 }
 
 // u32
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u32_to_le_bytes(x: u32) -> u32Word {
     u32Word::from_array(u32::to_le_bytes(x))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u32_to_be_bytes(x: u32) -> u32Word {
     u32Word::from_array(u32::to_be_bytes(x))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u32_from_be_bytes(s: u32Word) -> u32 {
     u32::from_be_bytes(s.0)
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u32_from_le_bytes(s: u32Word) -> u32 {
     u32::from_le_bytes(s.0)
 }
 
 // u64
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u64_to_le_bytes(x: u64) -> u64Word {
     u64Word::from_array(u64::to_le_bytes(x))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u64_to_be_bytes(x: u64) -> u64Word {
     u64Word::from_array(u64::to_be_bytes(x))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u64_from_be_bytes(s: u64Word) -> u64 {
     u64::from_be_bytes(s.0)
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u64_from_le_bytes(s: u64Word) -> u64 {
     u64::from_le_bytes(s.0)
 }
 
 // u128
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u128_to_le_bytes(x: u128) -> u128Word {
     u128Word::from_array(u128::to_le_bytes(x))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u128_to_be_bytes(x: u128) -> u128Word {
     u128Word::from_array(u128::to_be_bytes(x))
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u128_from_be_bytes(s: u128Word) -> u128 {
     u128::from_be_bytes(s.0)
 }
 
+#[cfg_attr(feature="use_attributes", library(hacspec))]
 pub fn u128_from_le_bytes(s: u128Word) -> u128 {
     u128::from_le_bytes(s.0)
 }

--- a/spec-examples/src/blake2/blake2b.rs
+++ b/spec-examples/src/blake2/blake2b.rs
@@ -30,7 +30,7 @@ const IVS: StateS = StateS(secret_array!(
         0x510E_527F,
         0x9B05_688C,
         0x1F83_D9AB,
-        0x5BE0_CD19,
+        0x5BE0_CD19
     ]
 ));
 
@@ -207,5 +207,5 @@ pub fn blake2<Word: UnsignedSecretInteger>(data: &ByteSeq, alg: BlakeVariant) ->
 }
 
 pub fn blake2b(data: &ByteSeq) -> DigestB {
-    DigestB::from_seq(&blake2(data, BlakeVariant::Blake2B))
+    DigestB::from_seq(&blake2::<U64>(data, BlakeVariant::Blake2B))
 }

--- a/spec-examples/src/blake2/blake2b.rs
+++ b/spec-examples/src/blake2/blake2b.rs
@@ -1,8 +1,6 @@
 // Import hacspec and all needed definitions.
 use hacspec::prelude::*;
 
-array!(StateB, 8, U64);
-array!(StateS, 8, U32);
 bytes!(DigestB, 64);
 
 array!(Sigma, 16 * 12, usize);
@@ -20,7 +18,7 @@ static SIGMA: Sigma = Sigma([
     9, 10, 11, 12, 13, 14, 15, 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3,
 ]);
 
-const IVS: StateS = StateS(secret_array!(
+const IVS: State<U32> = State(secret_array!(
     U32,
     [
         0x6A09_E667,
@@ -34,7 +32,7 @@ const IVS: StateS = StateS(secret_array!(
     ]
 ));
 
-const IVB: StateB = StateB(secret_array!(
+const IVB: State<U64> = State(secret_array!(
     U64,
     [
         0x6a09_e667_f3bc_c908u64,
@@ -98,11 +96,11 @@ pub trait HasIV<Word: UnsignedSecretInteger> {
 }
 
 impl HasIV<U64> for State<U64> {
-    fn iv() -> State<U64> { State::from_seq(&IVB) }
+    fn iv() -> State<U64> { IVB }
 }
 
 impl HasIV<U32> for State<U32> {
-    fn iv() -> State<U32> { State::from_seq(&IVS) }
+    fn iv() -> State<U32> { IVS }
 }
 
 #[derive(Clone, Copy)]

--- a/spec-examples/src/blake2/blake2b.rs
+++ b/spec-examples/src/blake2/blake2b.rs
@@ -2,6 +2,7 @@
 use hacspec::prelude::*;
 
 array!(StateB, 8, U64);
+array!(StateS, 8, U32);
 bytes!(DigestB, 64);
 
 array!(Sigma, 16 * 12, usize);
@@ -18,6 +19,20 @@ static SIGMA: Sigma = Sigma([
     1, 4, 10, 5, 10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8,
     9, 10, 11, 12, 13, 14, 15, 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3,
 ]);
+
+const IVS: StateS = StateS(secret_array!(
+    U32,
+    [
+        0x6A09_E667,
+        0xBB67_AE85,
+        0x3C6E_F372,
+        0xA54F_F53A,
+        0x510E_527F,
+        0x9B05_688C,
+        0x1F83_D9AB,
+        0x5BE0_CD19,
+    ]
+));
 
 const IVB: StateB = StateB(secret_array!(
     U64,
@@ -84,6 +99,10 @@ pub trait HasIV<Word: UnsignedSecretInteger> {
 
 impl HasIV<U64> for State<U64> {
     fn iv() -> State<U64> { State::from_seq(&IVB) }
+}
+
+impl HasIV<U32> for State<U32> {
+    fn iv() -> State<U32> { State::from_seq(&IVS) }
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
Thanks to the addition in the library of 
* parametric arrays ;
* various conversion functions for public and secret integers
* enhanced traits for public and secret integers

I'm able to write a generic version of Blake. Note : for now the Blake code is only suitable for Blake2b, as I was not sure what to tweak to get Blake2s right. But it should be easy to do since all the generic architecture is in place.