### PR TITLE
Deriving Numeric trait for structs and named tuples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "hacspec",
     "hacspec-dev",
+    "hacspec-derive",
     "secret-integers",
     "abstract-integers",
     "spec-examples",

--- a/hacspec-derive/Cargo.toml
+++ b/hacspec-derive/Cargo.toml
@@ -13,3 +13,4 @@ proc-macro = true
 hacspec = { path = "../hacspec" }
 syn = "1.0"
 quote = "1.0"
+proc-macro2= "1.0.17"

--- a/hacspec-derive/Cargo.toml
+++ b/hacspec-derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hacspec-derive"
+version = "0.1.0"
+authors = ["Denis Merigoux <denis.merigoux@gmail.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+hacspec = { path = "../hacspec" }
+syn = "1.0"
+quote = "1.0"

--- a/hacspec-derive/src/lib.rs
+++ b/hacspec-derive/src/lib.rs
@@ -1,0 +1,200 @@
+extern crate hacspec;
+extern crate proc_macro;
+extern crate quote;
+extern crate syn;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(Numeric)]
+pub fn derive_numeric_impl(input_struct: TokenStream) -> TokenStream {
+    let input_ast = parse_macro_input!(input_struct as DeriveInput);
+
+    // Used in the quasi-quotation below as `#name`.
+    let name = input_ast.ident;
+    let generics = input_ast.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let expanded = quote! {
+        impl #impl_generics Add for #name #ty_generics #where_clause {
+            type Output = Self;
+
+            fn add(self, rhs: Self) -> Self {
+                todo!();
+            }
+        }
+
+        impl #impl_generics Sub for #name #ty_generics #where_clause {
+            type Output = Self;
+
+            fn sub(self, rhs: Self) -> Self {
+                todo!();
+            }
+        }
+
+        impl #impl_generics Mul for #name #ty_generics #where_clause {
+            type Output = Self;
+
+            fn mul(self, rhs: Self) -> Self {
+                todo!();
+            }
+        }
+
+        impl #impl_generics BitXor for #name #ty_generics #where_clause {
+            type Output = Self;
+
+            fn bitxor(self, rhs: Self) -> Self {
+                todo!();
+            }
+        }
+
+        impl #impl_generics BitOr for #name #ty_generics #where_clause {
+            type Output = Self;
+
+            fn bitor(self, rhs: Self) -> Self {
+                todo!();
+            }
+        }
+
+        impl #impl_generics BitAnd for #name #ty_generics #where_clause {
+            type Output = Self;
+
+            fn bitand(self, rhs: Self) -> Self {
+                todo!();
+            }
+        }
+
+        impl #impl_generics Shl<usize> for #name #ty_generics #where_clause {
+            type Output = Self;
+
+            fn shl(self, v: usize) -> Self {
+                todo!();
+            }
+        }
+
+        impl #impl_generics Shr<usize> for #name #ty_generics #where_clause {
+            type Output = Self;
+
+            fn shr(self, v: usize) -> Self {
+                todo!();
+            }
+        }
+
+        impl #impl_generics Not for #name #ty_generics #where_clause {
+            type Output = Self;
+
+            fn not(self) -> Self {
+                todo!();
+            }
+        }
+
+        impl #impl_generics ModNumeric for #name #ty_generics #where_clause  {
+            /// (self - rhs) % n.
+            fn sub_mod(self, rhs: Self, n: Self) -> Self {
+                todo!();
+            }
+            /// `(self + rhs) % n`
+            fn add_mod(self, rhs: Self, n: Self) -> Self {
+                todo!();
+            }
+            /// `(self * rhs) % n`
+            fn mul_mod(self, rhs: Self, n: Self) -> Self {
+                todo!();
+            }
+            /// `(self ^ exp) % n`
+            fn pow_mod(self, exp: Self, n: Self) -> Self {
+                todo!();
+            }
+            /// `self % n`
+            fn modulo(self, n: Self) -> Self {
+                todo!();
+            }
+            /// `self % n` that always returns a positive integer
+            fn signed_modulo(self, n: Self) -> Self {
+                todo!();
+            }
+            /// `|self|`
+            fn absolute(self) -> Self {
+                todo!();
+            }
+        }
+
+        impl #impl_generics Numeric for #name #ty_generics #where_clause {
+            /// Return largest value that can be represented.
+            fn max_val() -> Self  {
+                todo!();
+            }
+
+            fn wrap_add(self, rhs: Self) -> Self  {
+                todo!();
+            }
+            fn wrap_sub(self, rhs: Self) -> Self  {
+                todo!();
+            }
+            fn wrap_mul(self, rhs: Self) -> Self  {
+                todo!();
+            }
+            fn wrap_div(self, rhs: Self) -> Self  {
+                todo!();
+            }
+
+            /// `self ^ exp` where `exp` is a `u32`.
+            fn exp(self, exp: u32) -> Self  {
+                todo!();
+            }
+            /// `self ^ exp` where `exp` is a `Self`.
+            fn pow_self(self, exp: Self) -> Self  {
+                todo!();
+            }
+            /// Division.
+            fn divide(self, rhs: Self) -> Self  {
+                todo!();
+            }
+            /// Invert self modulo n.
+            fn inv(self, n: Self) -> Self  {
+                todo!();
+            }
+
+            // Comparison functions returning bool.
+            fn equal(self, other: Self) -> bool  {
+                todo!();
+            }
+            fn greater_than(self, other: Self) -> bool  {
+                todo!();
+            }
+            fn greater_than_or_qual(self, other: Self) -> bool  {
+                todo!();
+            }
+            fn less_than(self, other: Self) -> bool  {
+                todo!();
+            }
+            fn less_than_or_equal(self, other: Self) -> bool  {
+                todo!();
+            }
+
+            // Comparison functions returning a bit mask (0x0..0 or 0xF..F).
+            fn not_equal_bm(self, other: Self) -> Self  {
+                todo!();
+            }
+            fn equal_bm(self, other: Self) -> Self  {
+                todo!();
+            }
+            fn greater_than_bm(self, other: Self) -> Self  {
+                todo!();
+            }
+            fn greater_than_or_equal_bm(self, other: Self) -> Self {
+                todo!();
+            }
+            fn less_than_bm(self, other: Self) -> Self  {
+                todo!();
+            }
+            fn less_than_or_equal_bm(self, other: Self) -> Self  {
+                todo!();
+            }
+        }
+
+    };
+
+    proc_macro::TokenStream::from(expanded)
+}

--- a/hacspec-derive/tests/test_derive.rs
+++ b/hacspec-derive/tests/test_derive.rs
@@ -5,15 +5,12 @@ use hacspec_derive::*;
 #[derive(Default, Clone, Debug, Numeric)]
 struct NumericStruct {
     fst: PublicSeq<u8>,
-    snd: PublicSeq<u8>
+    snd: PublicSeq<u8>,
 }
 
 #[allow(dead_code)]
 #[derive(Default, Clone, Debug, Numeric)]
-struct NumericPair(
-    PublicSeq<u8>,
-    PublicSeq<u8>
-);
+struct NumericPair(PublicSeq<u8>, PublicSeq<u8>);
 
 #[allow(dead_code)]
 #[derive(Default, Clone, Debug, Numeric)]
@@ -21,8 +18,14 @@ struct NumericEmpty {}
 
 #[test]
 fn test_struct() -> () {
-    let s1 = NumericStruct { fst: PublicSeq::from_vec(vec![1,2]), snd: PublicSeq::from_vec(vec![0,1,2])};
-    let s2 = NumericStruct { fst: PublicSeq::from_vec(vec![1,2]), snd: PublicSeq::from_vec(vec![0,1,2])};
+    let s1 = NumericStruct {
+        fst: PublicSeq::from_vec(vec![1, 2]),
+        snd: PublicSeq::from_vec(vec![0, 1, 2]),
+    };
+    let s2 = NumericStruct {
+        fst: PublicSeq::from_vec(vec![1, 2]),
+        snd: PublicSeq::from_vec(vec![0, 1, 2]),
+    };
     let s3 = s1.clone() + s2.clone();
     let s4 = s3 - s1;
     let _ = s2 * s4;
@@ -30,8 +33,14 @@ fn test_struct() -> () {
 
 #[test]
 fn test_pair() -> () {
-    let s1 = NumericPair (PublicSeq::from_vec(vec![1,2]), PublicSeq::from_vec(vec![0,1,2]));
-    let s2 = NumericPair (PublicSeq::from_vec(vec![1,2]), PublicSeq::from_vec(vec![0,1,2]));
+    let s1 = NumericPair(
+        PublicSeq::from_vec(vec![1, 2]),
+        PublicSeq::from_vec(vec![0, 1, 2]),
+    );
+    let s2 = NumericPair(
+        PublicSeq::from_vec(vec![1, 2]),
+        PublicSeq::from_vec(vec![0, 1, 2]),
+    );
     let s3 = s1.clone() + s2.clone();
     let s4 = s3 - s1;
     let _ = s2 * s4;

--- a/hacspec-derive/tests/test_derive.rs
+++ b/hacspec-derive/tests/test_derive.rs
@@ -1,0 +1,47 @@
+use hacspec::prelude::*;
+use hacspec_derive::*;
+
+#[allow(dead_code)]
+#[derive(Default, Clone, Debug, Numeric)]
+struct NumericStruct {
+    fst: PublicSeq<u8>,
+    snd: PublicSeq<u8>
+}
+
+#[allow(dead_code)]
+#[derive(Default, Clone, Debug, Numeric)]
+struct NumericPair(
+    PublicSeq<u8>,
+    PublicSeq<u8>
+);
+
+#[allow(dead_code)]
+#[derive(Default, Clone, Debug, Numeric)]
+struct NumericEmpty {}
+
+#[test]
+fn test_struct() -> () {
+    let s1 = NumericStruct { fst: PublicSeq::from_vec(vec![1,2]), snd: PublicSeq::from_vec(vec![0,1,2])};
+    let s2 = NumericStruct { fst: PublicSeq::from_vec(vec![1,2]), snd: PublicSeq::from_vec(vec![0,1,2])};
+    let s3 = s1.clone() + s2.clone();
+    let s4 = s3 - s1;
+    let _ = s2 * s4;
+}
+
+#[test]
+fn test_pair() -> () {
+    let s1 = NumericPair (PublicSeq::from_vec(vec![1,2]), PublicSeq::from_vec(vec![0,1,2]));
+    let s2 = NumericPair (PublicSeq::from_vec(vec![1,2]), PublicSeq::from_vec(vec![0,1,2]));
+    let s3 = s1.clone() + s2.clone();
+    let s4 = s3 - s1;
+    let _ = s2 * s4;
+}
+
+#[test]
+fn test_empty() -> () {
+    let s1 = NumericEmpty {};
+    let s2 = NumericEmpty {};
+    let s3 = s1.clone() + s2.clone();
+    let s4 = s3 - s1;
+    let _ = s2 * s4;
+}

--- a/hacspec-dev/tests/.gitignore
+++ b/hacspec-dev/tests/.gitignore
@@ -1,0 +1,2 @@
+sample_test_vector_out.json
+test_vector_write.json

--- a/hacspec/src/math_util.rs
+++ b/hacspec/src/math_util.rs
@@ -1,6 +1,6 @@
-///! 
+///!
 ///! A set of mathematical utility functions.
-///! 
+///!
 use crate::prelude::*;
 
 #[inline]
@@ -34,6 +34,7 @@ pub fn poly_add<T: Numeric + Copy>(x: &[T], y: &[T], n: T) -> Vec<T> {
 }
 
 /// Polynomial multiplication using operand scanning without modulo.
+#[allow(dead_code)]
 #[inline]
 pub(crate) fn poly_mul_plain<T: Numeric + Copy>(x: &[T], y: &[T], _n: T) -> Vec<T> {
     let mut out = vec![T::default(); x.len() + y.len()];
@@ -47,6 +48,7 @@ pub(crate) fn poly_mul_plain<T: Numeric + Copy>(x: &[T], y: &[T], _n: T) -> Vec<
 
 /// Polynomial multiplication using operand scanning.
 /// This is very inefficient and prone to side-channel attacks.
+#[allow(dead_code)]
 #[inline]
 pub(crate) fn poly_mul_op_scanning<T: Numeric + Copy>(x: &[T], y: &[T], n: T) -> Vec<T> {
     let mut out = vec![T::default(); x.len() + y.len()];

--- a/hacspec/src/traits.rs
+++ b/hacspec/src/traits.rs
@@ -73,8 +73,11 @@ pub trait Integer: Numeric {
 
     // Some useful values.
     // Not constants because math integers can't do that.
+    #[allow(non_snake_case)]
     fn ZERO() -> Self;
+    #[allow(non_snake_case)]
     fn ONE() -> Self;
+    #[allow(non_snake_case)]
     fn TWO() -> Self;
 
     /// Get an integer with value `val`.

--- a/spec-examples/Cargo.toml
+++ b/spec-examples/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 hacspec = { path = "../hacspec" }
+hacspec-derive = { path = "../hacspec-derive" }
 secret_integers = { path = "../secret-integers" }
 abstract_integers = { path = "../abstract-integers" }
 

--- a/spec-examples/src/lib.rs
+++ b/spec-examples/src/lib.rs
@@ -7,3 +7,13 @@ pub mod sha2;
 pub mod hkdf;
 pub mod hmac;
 pub mod p256;
+
+use hacspec::prelude::*;
+use hacspec_derive::*;
+
+#[allow(dead_code)]
+#[derive(Default, Clone, Debug, Numeric)]
+struct NumericPair {
+    fst: ByteSeq,
+    snd: ByteSeq
+}

--- a/spec-examples/src/lib.rs
+++ b/spec-examples/src/lib.rs
@@ -7,13 +7,3 @@ pub mod sha2;
 pub mod hkdf;
 pub mod hmac;
 pub mod p256;
-
-use hacspec::prelude::*;
-use hacspec_derive::*;
-
-#[allow(dead_code)]
-#[derive(Default, Clone, Debug, Numeric)]
-struct NumericPair {
-    fst: ByteSeq,
-    snd: ByteSeq
-}

--- a/spec-examples/tests/.gitignore
+++ b/spec-examples/tests/.gitignore
@@ -1,0 +1,1 @@
+aes_gcm_test_vector_out.json


### PR DESCRIPTION
Please see `hacspec-derive/tests/test_derive.rs` for an example of how to use the derivation system.

Operations for structs are assumed to be just field-wise operations returning in the end a whole struct. Operations like comparing are not implemented since it's unclear what would be the semantics in that case.