### PR TITLE
Improve chacha20 block to match RFC

### DIFF
--- a/examples/hacspec-chacha20/src/chacha20.rs
+++ b/examples/hacspec-chacha20/src/chacha20.rs
@@ -53,7 +53,7 @@ fn chacha_double_round(state: State) -> State {
 }
 
 pub fn chacha20_constants_init() -> Seq<U32> {
-    let mut constants = Seq::new(4);
+    let mut constants = Seq::<U32>::new(4);
     constants[0] = U32(0x6170_7865u32);
     constants[1] = U32(0x3320_646eu32);
     constants[2] = U32(0x7962_2d32u32);
@@ -62,7 +62,7 @@ pub fn chacha20_constants_init() -> Seq<U32> {
 }
 
 pub fn chacha20_key_to_u32s(key: Key) -> Seq<U32> {
-    let mut uints = Seq::new(8);
+    let mut uints = Seq::<U32>::new(8);
     uints[0] = U32_from_le_bytes(U32Word::from_slice_range(&key, 0..4));
     uints[1] = U32_from_le_bytes(U32Word::from_slice_range(&key, 4..8));
     uints[2] = U32_from_le_bytes(U32Word::from_slice_range(&key, 8..12));
@@ -75,7 +75,7 @@ pub fn chacha20_key_to_u32s(key: Key) -> Seq<U32> {
 }
 
 pub fn chacha20_iv_to_u32s(iv: IV) -> Seq<U32> {
-    let mut uints = Seq::new(3);
+    let mut uints = Seq::<U32>::new(3);
     uints[0] = U32_from_le_bytes(U32Word::from_slice_range(&iv, 0..4));
     uints[1] = U32_from_le_bytes(U32Word::from_slice_range(&iv, 4..8));
     uints[2] = U32_from_le_bytes(U32Word::from_slice_range(&iv, 8..12));
@@ -83,7 +83,7 @@ pub fn chacha20_iv_to_u32s(iv: IV) -> Seq<U32> {
 }
 
 pub fn chacha20_ctr_to_seq(ctr: U32) -> Seq<U32> {
-    let mut uints = Seq::new(1);
+    let mut uints = Seq::<U32>::new(1);
     uints[0] = ctr;
     uints
 }

--- a/examples/hacspec-chacha20/src/chacha20.rs
+++ b/examples/hacspec-chacha20/src/chacha20.rs
@@ -52,25 +52,49 @@ fn chacha_double_round(state: State) -> State {
     chacha_quarter_round(3, 4, 9, 14, state)
 }
 
+pub fn chacha20_constants_init() -> Seq<U32> {
+    let mut constants = Seq::new(4);
+    constants[0] = U32(0x6170_7865u32);
+    constants[1] = U32(0x3320_646eu32);
+    constants[2] = U32(0x7962_2d32u32);
+    constants[3] = U32(0x6b20_6574u32);
+    constants
+}
+
+pub fn chacha20_key_to_u32s(key: Key) -> Seq<U32> {
+    let mut uints = Seq::new(8);
+    uints[0] = U32_from_le_bytes(U32Word::from_slice_range(&key, 0..4));
+    uints[1] = U32_from_le_bytes(U32Word::from_slice_range(&key, 4..8));
+    uints[2] = U32_from_le_bytes(U32Word::from_slice_range(&key, 8..12));
+    uints[3] = U32_from_le_bytes(U32Word::from_slice_range(&key, 12..16));
+    uints[4] = U32_from_le_bytes(U32Word::from_slice_range(&key, 16..20));
+    uints[5] = U32_from_le_bytes(U32Word::from_slice_range(&key, 20..24));
+    uints[6] = U32_from_le_bytes(U32Word::from_slice_range(&key, 24..28));
+    uints[7] = U32_from_le_bytes(U32Word::from_slice_range(&key, 28..32));
+    uints
+}
+
+pub fn chacha20_iv_to_u32s(iv: IV) -> Seq<U32> {
+    let mut uints = Seq::new(3);
+    uints[0] = U32_from_le_bytes(U32Word::from_slice_range(&iv, 0..4));
+    uints[1] = U32_from_le_bytes(U32Word::from_slice_range(&iv, 4..8));
+    uints[2] = U32_from_le_bytes(U32Word::from_slice_range(&iv, 8..12));
+    uints
+}
+
+pub fn chacha20_ctr_to_seq(ctr: U32) -> Seq<U32> {
+    let mut uints = Seq::new(1);
+    uints[0] = ctr;
+    uints
+}
+
 pub fn chacha_block_init(key: Key, ctr: U32, iv: IV) -> State {
-    State([
-        U32(0x6170_7865u32),
-        U32(0x3320_646eu32),
-        U32(0x7962_2d32u32),
-        U32(0x6b20_6574u32),
-        U32_from_le_bytes(U32Word::from_slice_range(&key, 0..4)),
-        U32_from_le_bytes(U32Word::from_slice_range(&key, 4..8)),
-        U32_from_le_bytes(U32Word::from_slice_range(&key, 8..12)),
-        U32_from_le_bytes(U32Word::from_slice_range(&key, 12..16)),
-        U32_from_le_bytes(U32Word::from_slice_range(&key, 16..20)),
-        U32_from_le_bytes(U32Word::from_slice_range(&key, 20..24)),
-        U32_from_le_bytes(U32Word::from_slice_range(&key, 24..28)),
-        U32_from_le_bytes(U32Word::from_slice_range(&key, 28..32)),
-        ctr,
-        U32_from_le_bytes(U32Word::from_slice_range(&iv, 0..4)),
-        U32_from_le_bytes(U32Word::from_slice_range(&iv, 4..8)),
-        U32_from_le_bytes(U32Word::from_slice_range(&iv, 8..12)),
-    ])
+    State::from_seq(
+        &chacha20_constants_init()
+            .concat(&chacha20_key_to_u32s(key))
+            .concat(&chacha20_ctr_to_seq(ctr))
+            .concat(&chacha20_iv_to_u32s(iv)),
+    )
 }
 
 pub fn chacha_block_inner(key: Key, ctr: U32, iv: IV) -> State {

--- a/fstar/Hacspec.Lib.fst
+++ b/fstar/Hacspec.Lib.fst
@@ -231,6 +231,15 @@ let seq_update
   =
   LSeq.update_sub #a #(LSeq.length s) s start (LSeq.length input) input
 
+let seq_concat
+  (#a: Type)
+  (s1 :seq a)
+  (s2: seq a{range (LSeq.length s1 + LSeq.length s2) U32})
+  : lseq a (LSeq.length s1 + LSeq.length s2)
+  =
+  LSeq.concat #a #(LSeq.length s1) #(LSeq.length s2) s1 s2
+
+
 (**** Chunking *)
 
 let seq_num_chunks (#a: Type) (s: seq a) (chunk_len: uint_size{chunk_len > 0}) : uint_size =

--- a/language/src/rustspec_to_fstar.rs
+++ b/language/src/rustspec_to_fstar.rs
@@ -645,6 +645,7 @@ fn translate_expression<'a>(e: Expression, typ_dict: &'a TypeDict) -> RcDoc<'a, 
         Expression::FuncCall(prefix, name, args) => {
             let (func_name, additional_args) =
                 translate_func_name(prefix.clone(), name.0.clone(), typ_dict);
+            let total_args = args.len() + additional_args.len();
             func_name
                 // We append implicit arguments first
                 .append(RcDoc::concat(
@@ -656,6 +657,11 @@ fn translate_expression<'a>(e: Expression, typ_dict: &'a TypeDict) -> RcDoc<'a, 
                 .append(RcDoc::concat(args.into_iter().map(|((arg, _), _)| {
                     RcDoc::space().append(make_paren(translate_expression(arg, typ_dict)))
                 })))
+                .append(if total_args == 0 {
+                    RcDoc::space().append(RcDoc::as_string("()"))
+                } else {
+                    RcDoc::nil()
+                })
         }
         Expression::MethodCall(sel_arg, sel_typ, (f, _), args) => {
             let (func_name, additional_args) =

--- a/lib/src/array.rs
+++ b/lib/src/array.rs
@@ -335,6 +335,14 @@ macro_rules! generic_array {
                 a
             }
 
+            #[cfg_attr(feature="use_attributes", in_hacspec)]
+            pub fn concat<A: SeqTrait<T>>(&self, next: &A) -> Seq<T> {
+                let mut out = Seq::new(self.len() + next.len());
+                out = out.update_start(self);
+                out = out.update_slice(self.len(), next, 0, next.len());
+                out
+            }
+
             #[cfg_attr(feature = "use_attributes", in_hacspec($name))]
             pub fn from_slice_range<A: SeqTrait<T>>(input: &A, r: Range<usize>) -> Self {
                 Self::from_slice(input, r.start, r.end - r.start)

--- a/lib/src/seq.rs
+++ b/lib/src/seq.rs
@@ -61,6 +61,14 @@ macro_rules! declare_seq_with_contents_constraints_impl {
                 a = a.update_slice(0, input, start, len);
                 a
             }
+            
+            #[cfg_attr(feature="use_attributes", in_hacspec)]
+            pub fn concat<A: SeqTrait<T>>(&self, next: &A) -> Self {
+                let mut out = Self::new(self.len() + next.len());
+                out = out.update_start(self);
+                out = out.update_slice(self.len(), next, 0, next.len());
+                out
+            }
 
             #[cfg_attr(feature="use_attributes", in_hacspec)]
             pub fn from_slice_range<A: SeqTrait<T>>(input: &A, r: Range<usize>) -> Self {


### PR DESCRIPTION
Cosmetic changes to Chacha20 so that it matches https://tools.ietf.org/html/rfc7539#section-2.3.1. Introduced the `concat` function in the lib which could be handy elsewhere.