### PR TITLE
adapt to Rust nightly changes

### DIFF
--- a/language/src/ast_to_rustspec.rs
+++ b/language/src/ast_to_rustspec.rs
@@ -1004,6 +1004,10 @@ fn translate_expr(
             sess.span_rustspec_err(e.span.clone(), "const blocks are not allowed in Hacspec");
             Err(())
         }
+        ExprKind::Underscore => {
+            sess.span_rustspec_err(e.span.clone(), "underscores are not allowed in Hacspec");
+            Err(())
+        }
     }
 }
 

--- a/language/src/ast_to_rustspec.rs
+++ b/language/src/ast_to_rustspec.rs
@@ -392,6 +392,7 @@ fn translate_expr(
     arr_typs: &ArrayTypes,
     e: &Expr,
 ) -> TranslationResult<Spanned<ExprTranslationResult>> {
+    #[allow(unreachable_patterns)]
     match &e.kind {
         ExprKind::Binary(op, e1, e2) => Ok((
             ExprTranslationResult::TransExpr(Expression::Binary(
@@ -1006,6 +1007,10 @@ fn translate_expr(
         }
         ExprKind::Underscore => {
             sess.span_rustspec_err(e.span.clone(), "underscores are not allowed in Hacspec");
+            Err(())
+        }
+        _ => {
+            sess.span_rustspec_err(e.span.clone(), "this expression is not allowed in Hacspec");
             Err(())
         }
     }

--- a/utils/provider/Cargo.toml
+++ b/utils/provider/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evercrypt = "0.0.1"
+evercrypt = "0.0.3"
 hacspec-lib = { path = "../../lib" }
 hacspec-chacha20poly1305 = { path = "../../examples/hacspec-chacha20poly1305" }
 hacspec-chacha20 = { path = "../../examples/hacspec-chacha20" }


### PR DESCRIPTION
https://github.com/rust-lang/rust/commit/8cf35643106bba09b5d6c71ceac74dc58573f371 added `ExprKind::Underscore`. I didn't look into how it actually works but disallowed it for now.