### PR TITLE
initial no_std work

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Install no_std target
         run: rustup target add thumbv7em-none-eabi
       - name: Build no_std hacspec-lib
-        run: cargo build --target thumbv7em-none-eabi -p hacspec-lib --no-default-features --features alloc
+        run: cargo build --target thumbv7em-none-eabi -p hacspec-lib --no-default-features --features alloc -Zfeatures=all

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,3 +26,14 @@ jobs:
         run: RUST_NIGHTLY=nightly-2021-11-14 ./lib/get_func_stats.sh
       - name: Build and test Hacspec compiler
         run: cargo clean && cargo build -p hacspec-lib && cd language && cargo test --verbose
+
+  build_no_std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install no_std target
+        run: rustup target add thumbv7em-none-eabi
+      - name: Build no_std hacspec-lib
+        run: cargo build --target thumbv7em-none-eabi -p hacspec-lib --no-default-features --features alloc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,3 @@ default-members = [
     "examples/sha512",
 ]
 exclude = [ "language" ]
-resolver = "2"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,12 +10,16 @@ readme = "README.md"
 repository = "https://github.com/hacspec/hacspec"
 
 [dependencies]
-num = "0.4"
-secret_integers = { path = "../utils/secret-integers", version = "0.1.7" } #FIXME: publish new version
-abstract_integers = { path = "../utils/abstract-integers", version = "0.1.5" } #FIXME: publish new version
+num = { version = "0.4", default-features = false }
+secret_integers = { path = "../utils/secret-integers", optional = true, version = "0.1.7" } #FIXME: publish new version
+abstract_integers = { path = "../utils/abstract-integers", version = "0.1.5", default-features = false } #FIXME: publish new version
 hacspec-attributes = { path = "../utils/attributes",  optional = true, version = "0.1.0-beta.1" }
 
 [features]
+default = ["std"]
+alloc = ["secret_integers"]
+std = ["alloc", "secret_integers", "num/std", "abstract_integers/std"]
+
 use_attributes = ["hacspec-attributes", "hacspec-attributes/print_attributes"]
 
 [dev-dependencies]

--- a/lib/src/array.rs
+++ b/lib/src/array.rs
@@ -150,7 +150,7 @@ macro_rules! _array_base {
                 $l
             }
             #[cfg_attr(feature = "use_attributes", not_hacspec($name))]
-            fn iter(&self) -> std::slice::Iter<$t> {
+            fn iter(&self) -> core::slice::Iter<$t> {
                 self.0.iter()
             }
 
@@ -269,7 +269,7 @@ macro_rules! _array_base {
 
         impl $name {
             fn hex_string_to_vec(s: &str) -> Vec<$t> {
-                debug_assert!(s.len() % std::mem::size_of::<$t>() == 0);
+                debug_assert!(s.len() % core::mem::size_of::<$t>() == 0);
                 let b: Result<Vec<$t>, ParseIntError> = (0..s.len())
                     .step_by(2)
                     .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map(<$t>::from))
@@ -422,7 +422,7 @@ macro_rules! generic_array {
                 $l
             }
             #[cfg_attr(feature = "use_attributes", not_hacspec($name))]
-            fn iter(&self) -> std::slice::Iter<T> {
+            fn iter(&self) -> core::slice::Iter<T> {
                 self.0.iter()
             }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -79,6 +79,13 @@
 //!
 //! See the [secret integers](`secret_integers`) for details.
 
+#![no_std]
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std as alloc;
+
 pub mod array;
 mod bigint_integers;
 mod machine_integers;

--- a/lib/src/machine_integers.rs
+++ b/lib/src/machine_integers.rs
@@ -8,6 +8,7 @@
 //! Secret machine integers are `U8, I8, U16, I16, U32, I32, U64, I64, U128, I128`.
 //!
 
+use crate::alloc::string::ToString;
 use crate::math_util::{ct_util::*, *};
 use crate::prelude::*;
 

--- a/lib/src/math_util/ct_poly.rs
+++ b/lib/src/math_util/ct_poly.rs
@@ -70,9 +70,9 @@ fn divstepsx<T: Integer + Copy>(
         // TODO: make swap constant time
         if delta > 0 && !g[0].equal(T::ZERO()) {
             delta = -delta;
-            std::mem::swap(&mut f, &mut g);
-            std::mem::swap(&mut q, &mut u);
-            std::mem::swap(&mut r, &mut v);
+            core::mem::swap(&mut f, &mut g);
+            core::mem::swap(&mut q, &mut u);
+            core::mem::swap(&mut r, &mut v);
         }
 
         delta = delta + 1;
@@ -111,7 +111,7 @@ fn poly_divx<T: Numeric + Copy>(v: &[T]) -> Vec<T> {
 
 /// Subtract quotient (bn/x^bd) from (an/x^ad)
 fn quot_sub<T: Integer + Copy>(an: &[T], ad: usize, bn: &[T], bd: usize, n: T) -> (Vec<T>, usize) {
-    let cd = std::cmp::max(ad, bd);
+    let cd = core::cmp::max(ad, bd);
     let x = monomial(T::ONE(), 1);
     let mut a = an.to_vec();
     let mut b = bn.to_vec();

--- a/lib/src/prelude.rs
+++ b/lib/src/prelude.rs
@@ -24,11 +24,17 @@ pub use abstract_integers::*;
 pub use hacspec_attributes::*;
 pub use secret_integers::*;
 
-pub use num::{self, traits::sign::Signed, BigUint, CheckedSub, Num, Zero};
-pub use std::num::ParseIntError;
-pub use std::ops::*;
-pub use std::str::FromStr;
-pub use std::{cmp::min, cmp::PartialEq, fmt, fmt::Debug};
+pub use alloc::fmt::Display;
+pub use alloc::format;
+pub use alloc::string::{String, ToString};
+pub use alloc::vec;
+pub use alloc::vec::Vec;
+
+pub use core::num::ParseIntError;
+pub use core::ops::*;
+pub use core::str::FromStr;
+pub use core::{cmp::min, cmp::PartialEq, fmt, fmt::Debug};
+pub use num::{self, traits::sign::Signed, CheckedSub, Num, Zero};
 
 bytes!(U16Word, 2);
 bytes!(U32Word, 4);
@@ -41,4 +47,4 @@ public_bytes!(u64Word, 8);
 public_bytes!(u128Word, 16);
 
 // Re-export some std lib functions
-pub use std::convert::TryFrom; // Allow down-casting of integers.
+pub use core::convert::TryFrom; // Allow down-casting of integers.

--- a/lib/src/seq.rs
+++ b/lib/src/seq.rs
@@ -252,7 +252,7 @@ macro_rules! declare_seq_with_contents_constraints_impl {
                 self.b.len()
             }
             #[cfg_attr(feature="use_attributes", not_hacspec)]
-            fn iter(&self) -> std::slice::Iter<T> {
+            fn iter(&self) -> core::slice::Iter<T> {
                 self.b.iter()
             }
 

--- a/lib/src/traits.rs
+++ b/lib/src/traits.rs
@@ -9,7 +9,7 @@ pub trait SeqTrait<T: Clone>:
     Index<usize, Output = T> + IndexMut<usize, Output = T> + Sized
 {
     fn len(&self) -> usize;
-    fn iter(&self) -> std::slice::Iter<T>;
+    fn iter(&self) -> core::slice::Iter<T>;
     fn create(len: usize) -> Self;
     /// Update this sequence with `l` elements of `v`, starting at `start_in`,
     /// at `start_out`.

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -4,7 +4,9 @@
 
 #[cfg(feature = "use_attributes")]
 use crate::prelude::*;
-use std::num::ParseIntError;
+use core::num::ParseIntError;
+
+use alloc::vec::Vec;
 
 #[cfg_attr(feature = "use_attributes", not_hacspec)]
 pub fn hex_string_to_bytes(s: &str) -> Vec<u8> {

--- a/lib/src/vec_util.rs
+++ b/lib/src/vec_util.rs
@@ -4,6 +4,7 @@
 ///! This includes sequences, arrays, and polynomials.
 ///!
 use crate::prelude::*;
+use alloc::vec::Vec;
 
 #[inline]
 #[cfg_attr(feature = "use_attributes", not_hacspec)]
@@ -43,7 +44,7 @@ where
 #[cfg_attr(feature = "use_attributes", not_hacspec)]
 /// Return vectors `x` and `y`, padded to maximum length of the two.
 pub(crate) fn normalize<T: Numeric + Copy>(x: &[T], y: &[T]) -> (Vec<T>, Vec<T>) {
-    let max_len = std::cmp::max(x.len(), y.len());
+    let max_len = core::cmp::max(x.len(), y.len());
     (pad(x, max_len), pad(y, max_len))
 }
 

--- a/utils/abstract-integers/Cargo.toml
+++ b/utils/abstract-integers/Cargo.toml
@@ -10,4 +10,9 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-num = "0.4"
+num = { version = "0.4", default-features = false }
+num-bigint = { version = "0.3", default-features = false }
+
+[features]
+default = ["std"]
+std = ["num/std", "num-bigint/std"]

--- a/utils/abstract-integers/src/abstract_int.rs
+++ b/utils/abstract-integers/src/abstract_int.rs
@@ -123,24 +123,24 @@ macro_rules! abstract_int {
             }
         }
 
-        impl std::fmt::Display for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl core::fmt::Display for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 let uint: BigInt = (*self).into();
                 write!(f, "{}", uint)
             }
         }
 
-        impl std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 let uint: BigInt = (*self).into();
                 write!(f, "{}", uint)
             }
         }
 
-        impl std::fmt::LowerHex for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        impl core::fmt::LowerHex for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 let val: BigInt = (*self).into();
-                std::fmt::LowerHex::fmt(&val, f)
+                core::fmt::LowerHex::fmt(&val, f)
             }
         }
     };
@@ -320,7 +320,7 @@ macro_rules! abstract_public {
         impl Eq for $name {}
 
         impl PartialOrd for $name {
-            fn partial_cmp(&self, other: &$name) -> Option<std::cmp::Ordering> {
+            fn partial_cmp(&self, other: &$name) -> Option<core::cmp::Ordering> {
                 let a: BigInt = (*self).into();
                 let b: BigInt = (*other).into();
                 a.partial_cmp(&b)
@@ -328,7 +328,7 @@ macro_rules! abstract_public {
         }
 
         impl Ord for $name {
-            fn cmp(&self, other: &$name) -> std::cmp::Ordering {
+            fn cmp(&self, other: &$name) -> core::cmp::Ordering {
                 self.partial_cmp(other).unwrap()
             }
         }

--- a/utils/abstract-integers/src/lib.rs
+++ b/utils/abstract-integers/src/lib.rs
@@ -61,11 +61,14 @@
 //! ```
 //!
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 // Re-exports
-pub use num::{bigint::Sign, traits, traits::identities::*, BigInt, BigUint, CheckedSub, Zero};
-pub use std::cmp::Ordering;
-pub use std::num::ParseIntError;
-pub use std::ops::*;
+pub use core::cmp::Ordering;
+pub use core::num::ParseIntError;
+pub use core::ops::*;
+pub use num::{traits, traits::identities::*, CheckedSub, Zero};
+pub use num_bigint::{BigInt, BigUint, Sign};
 
 pub mod abstract_int;
 pub mod nat_mod;

--- a/utils/abstract-integers/src/nat_mod.rs
+++ b/utils/abstract-integers/src/nat_mod.rs
@@ -4,24 +4,24 @@ macro_rules! modular_integer {
         #[derive(Clone, Copy, Default)]
         pub struct $name($base);
 
-        impl std::fmt::Display for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl core::fmt::Display for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 let uint: $base = (*self).into();
                 write!(f, "{}", uint)
             }
         }
 
-        impl std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 let uint: $base = (*self).into();
                 write!(f, "{}", uint)
             }
         }
 
-        impl std::fmt::LowerHex for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        impl core::fmt::LowerHex for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 let val: $base = (*self).into();
-                std::fmt::LowerHex::fmt(&val, f)
+                core::fmt::LowerHex::fmt(&val, f)
             }
         }
 

--- a/utils/secret-integers/src/lib.rs
+++ b/utils/secret-integers/src/lib.rs
@@ -72,8 +72,13 @@
 //! ```
 //!
 
-use std::num::Wrapping;
-use std::ops::*;
+#![no_std]
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+use core::num::Wrapping;
+use core::ops::*;
 
 macro_rules! define_wrapping_op {
     ($name:ident, $op:tt, $op_name:ident, $func_op:ident, $assign_name:ident, $assign_func:ident, $checked_func_op:ident) => {
@@ -205,7 +210,7 @@ macro_rules! define_secret_integer {
                         chunk_raw[i] = U8::declassify(chunk[i]);
                     }
                     $name::classify(unsafe {
-                        std::mem::transmute::<[u8;$bits/8], $repr>(
+                        core::mem::transmute::<[u8;$bits/8], $repr>(
                             chunk_raw
                         ).to_le()
                     })
@@ -216,7 +221,7 @@ macro_rules! define_secret_integer {
                 ints.iter().map(|int| {
                     let int = $name::declassify(*int);
                     let bytes : [u8;$bits/8] = unsafe {
-                         std::mem::transmute::<$repr, [u8;$bits/8]>(int.to_le())
+                         core::mem::transmute::<$repr, [u8;$bits/8]>(int.to_le())
                     };
                     let secret_bytes : Vec<U8> = bytes.iter().map(|x| U8::classify(*x)).collect();
                     secret_bytes
@@ -231,7 +236,7 @@ macro_rules! define_secret_integer {
                         chunk_raw[i] = U8::declassify(chunk[i]);
                     }
                     $name::classify(unsafe {
-                        std::mem::transmute::<[u8;$bits/8], $repr>(
+                        core::mem::transmute::<[u8;$bits/8], $repr>(
                             chunk_raw
                         ).to_be()
                     })
@@ -242,7 +247,7 @@ macro_rules! define_secret_integer {
                 ints.iter().map(|int| {
                     let int = $name::declassify(*int);
                     let bytes : [u8;$bits/8] = unsafe {
-                         std::mem::transmute::<$repr, [u8;$bits/8]>(int.to_be())
+                         core::mem::transmute::<$repr, [u8;$bits/8]>(int.to_be())
                     };
                     let secret_bytes : Vec<U8> = bytes.iter().map(|x| U8::classify(*x)).collect();
                     secret_bytes
@@ -290,22 +295,22 @@ macro_rules! define_secret_integer {
         define_unary_op!($name, !, Not, not);
 
         // Printing integers.
-        impl std::fmt::Display for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl core::fmt::Display for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 let uint: $repr = self.declassify();
                 write!(f, "{}", uint)
             }
         }
-        impl std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 let uint: $repr = self.declassify();
                 write!(f, "{}", uint)
             }
         }
-        impl std::fmt::LowerHex for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl core::fmt::LowerHex for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 let val: $repr = self.declassify();
-                std::fmt::LowerHex::fmt(&val, f)
+                core::fmt::LowerHex::fmt(&val, f)
             }
         }
         // impl Distribution<$name> for Standard {


### PR DESCRIPTION
Here's my work in progress branch to build with no_std (but still using alloc).

This mainly:

1. converts uses of `std::*` to `core::*` and `alloc::*` where possible
2. sets up features for std (as default) and no_std/alloc when std is not used
~~3. adds `examples/no_std`, which is a Cortex-M bare-metal application that can run in QEMU~~
~~4. adds a github workflow that runs `examples/no_std` in QEMU~~ (split out to follow-up)

~~This is work in progress, but I'd like to see what your CI thinks. :)~~
Update April '22:
- I gave this another look and rebased it to current master
- running the tests locally works fine
- `examples/no_std` builds (and imports hacspec-lib), but doesn't actually use any of it. We can do that later.
Update May 3rd:
- split out example and CI workflow