### PR TITLE
pin Rust nightly version for typechecker

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,5 +26,3 @@ jobs:
       run: RUST_NIGHTLY=nightly-2021-02-14 ./lib/get_func_stats.sh
     - name: Build and test F* compiler
       run: cargo clean && cd language && cargo +nightly test --verbose
-      env:
-        RUST_NIGHTLY: nightly

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Test Provider
       run: cargo test --verbose -p rc-tests
     - name: Get hacspec function stats
-      run: bash lib/get_func_stats.sh
+      run: RUST_NIGHTLY=nightly-2021-02-14 ./lib/get_func_stats.sh
     - name: Build and test F* compiler
       run: cargo clean && cd language && cargo +nightly test --verbose
       env:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         submodules: true
     - name: Prepare
-      run: rustup toolchain install nightly && rustup default nightly && rustup component add --toolchain nightly rustc-dev && rustup component add --toolchain nightly llvm-tools-preview
+      run: rustup toolchain install nightly-2021-02-14 && rustup default nightly-2021-02-14 && rustup component add --toolchain nightly-2021-02-14 rustc-dev && rustup component add --toolchain nightly-2021-02-14 llvm-tools-preview
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Get hacspec function stats
       run: RUST_NIGHTLY=nightly-2021-02-14 ./lib/get_func_stats.sh
     - name: Build and test F* compiler
-      run: cargo clean && cd language && cargo +nightly test --verbose
+      run: cargo clean && cd language && cargo +nightly-2021-02-14 test --verbose

--- a/Readme.md
+++ b/Readme.md
@@ -21,24 +21,34 @@ It is recommended to use the [hacspec standard library](https://crates.io/crates
 In order to ensure that the code is a hacspec one can use the typecheker.
 
 ### Typechecking
+Make sure you have at least `rustup 1.23.0`.
+The [`rust-toolchain`](./language/rust-toolchain) automatically picks the correct Rust nightly version and components.
+The compiler version is currently pinned to `nightly-2021-02-14`.
+
 First ensure that Rust nightly is installed and the typechecker is installed.
 
 ```bash
-rustup toolchain install nightly
-rustup component add --toolchain nightly rustc-dev
-cargo +nightly install hacspec
+rustup toolchain install nightly-2021-02-14
+rustup component add --toolchain nightly-2021-02-14 rustc-dev
+cargo +nightly-2021-02-14 install hacspec
+```
+
+Depending on your system you might also need `llvm-tools-preview`
+
+```bash
+rustup component add --toolchain nightly-2021-02-14 llvm-tools-preview
 ```
 
 In a hacspec crate or workspace directory typechecking can be done as follows now:
 
 ```bash
-cargo +nightly hacspec <crate-name>
+cargo +nightly-2021-02-14 hacspec <crate-name>
 ```
 
 Note that the crate needs to be compiled before it can be typechecked.
 
 ```bash
-cargo +nightly build
+cargo +nightly-2021-02-14 build
 ```
 
 If typechecking succeeds, it should show
@@ -51,8 +61,8 @@ If typechecking succeeds, it should show
 To generate F* or EasyCrypt code from hacspec the typechecker (see above) is required.
 
 ```bash
-cargo +nightly hacspec -o <fst-name>.fst <crate-name>
-cargo +nightly hacspec -o <ec-name>.ec <crate-name>
+cargo +nightly-2021-02-14 hacspec -o <fst-name>.fst <crate-name>
+cargo +nightly-2021-02-14 hacspec -o <ec-name>.ec <crate-name>
 ```
 
 # Repository Structure

--- a/language/Readme.md
+++ b/language/Readme.md
@@ -2,13 +2,11 @@
 
 ## Rust nightly
 
-To build and run the hacspec compiler, you will need to use nightly Rust with 
-additional components : 
-
-```
-rustup toolchain install nightly 
-rustup component add --toolchain nightly rustc-dev
-```
+To build and run the hacspec compiler, you will need to use nightly Rust with additional components.
+This is managed by the [`rust-toolchain`](./rust-toolchain) automatically.
+It picks the correct Rust nightly version and components.
+Make sure you have at least `rustup 1.23.0`.
+For manual installation please check the toolchain file.
 
 ## Usage
 
@@ -16,37 +14,14 @@ To build the compiler, simply launch `cargo build`.
 
 Due to technical limitations of the exposed API of the Rust compiler and the point 
 at which we divert the Rust AST into hacspec, only single-file crates are supported 
-at the moment. This is why all the crates in [hacspec-examples](../hacspec-examples)
+at the moment. This is why all the crates in [examples](../examples)
 only consist of a single file.
 
 Apart from this limitation, the hacspec compiler works as expected with imported 
 crates, letting you build modular programs using several crates that depend on 
 each other.
 
-The hacspec compiler shares its CLI with the Rust compiler, so you need to pass in 
-a lot of options. More importantly, because we rely on dependent crates being already
-compiled (e.g. by `cargo`), you need to pass as a search folder the `target` directory
-of the hacspec project you are doing.
-
-
-Let us suppose that you are developping some hacspec crate in the folder `~/foo`.
-Then, you should invoke the compiler from this folder ([hacspec/](./)) and this is what
-your typechecking invocation should look like:
-
-```
-cargo run -- \
-    -L ~/foo/target/debug/deps \
-    --crate-type=lib --edition=2018 \
-    --extern=hacspec_lib  \
-    --extern=<name_of_dependent_crate> \
-    -Zno-codegen \
-    ~/foo/src/lib.rs
-```
-
-If you want to compile to F* on top of typechecking,
-replace `-Zno-codegen` with `-o /path/to/Output.fst`.
-
-This process is cumbersome and some `cargo` hacking is needed to streamline it.
+Please see the main [readme](../Readme.md) for details on usage.
 
 ## Known bugs
 
@@ -58,4 +33,4 @@ already compiled in the `target/` folder. A simple `cargo clean` followed by
 ## Testing
 
 The compiler can be tested by launching `cargo test`. It typechecks and compile to F* all 
-the specs in [hacspec-examples/](hacspec-examples/).
+the specs in [examples/](../examples/).

--- a/language/rust-toolchain
+++ b/language/rust-toolchain
@@ -1,1 +1,3 @@
-nightly
+[toolchain]
+channel = "nightly-2021-02-14"
+components = [ "rustc-dev", "llvm-tools-preview" ]

--- a/lib/get_func_stats.sh
+++ b/lib/get_func_stats.sh
@@ -7,6 +7,7 @@ pushd $cwd
 
 NIGHTLY="${RUST_NIGHTLY:-nightly}"
 
+cargo +$NIGHTLY --version
 cargo +$NIGHTLY build --tests --features="use_attributes"
 
 REMOVE='\033[1;31m'


### PR DESCRIPTION
Pinning the Rust compiler to a version that we know is working for the typechecker.