### PR TITLE
Add dependencies automatically to typechecker

### DIFF
--- a/language/src/main.rs
+++ b/language/src/main.rs
@@ -234,6 +234,11 @@ fn read_crate(package_name: String, args: &mut Vec<String>, callbacks: &mut Hacs
     // This only works with debug builds.
     let deps = manifest.target_directory + "/debug/deps";
     callbacks.target_directory = deps;
+
+    // Add the dependencies as --extern for the hacpsec typechecker.
+    for dependency in package.dependencies.iter() {
+        args.push(format!("--extern={}", dependency.name.replace("-", "_")));
+    }
 }
 
 fn main() -> Result<(), ()> {

--- a/language/tests/run_tests.rs
+++ b/language/tests/run_tests.rs
@@ -39,12 +39,12 @@ fn run_poly1305_test() -> Result<(), Box<dyn std::error::Error>> {
     run_test(
         "hacspec-poly1305",
         Some("../fstar/Hacspec.Poly1305.fst"),
-        vec![""],
+        vec![],
     )?;
     run_test(
         "hacspec-poly1305",
         Some("../easycrypt/Hacspec_Poly1305.ec"),
-        vec![""],
+        vec![],
     )
 }
 
@@ -53,7 +53,7 @@ fn run_chacha20poly1305_test() -> Result<(), Box<dyn std::error::Error>> {
     run_test(
         "hacspec-chacha20poly1305",
         Some("../fstar/Hacspec.Chacha20Poly1305.fst"),
-        vec!["hacspec_chacha20", "hacspec_poly1305"],
+        vec![],
     )
 }
 
@@ -96,7 +96,7 @@ fn run_hmac_test() -> Result<(), Box<dyn std::error::Error>> {
     run_test(
         "hacspec-hmac",
         Some("../fstar/Hacspec.Hmac.fst"),
-        vec!["hacspec_sha256"],
+        vec![],
     )
 }
 
@@ -105,6 +105,6 @@ fn run_hkdf_test() -> Result<(), Box<dyn std::error::Error>> {
     run_test(
         "hacspec-hkdf",
         Some("../fstar/Hacspec.Hkdf.fst"),
-        vec!["hacspec_sha256", "hacspec_hmac"],
+        vec![],
     )
 }

--- a/language/tests/run_tests.rs
+++ b/language/tests/run_tests.rs
@@ -1,16 +1,9 @@
 use assert_cmd::prelude::*; // Add methods on commands
 use std::{env, process::Command}; // Run programs
 
-fn run_test(
-    package_name: &str,
-    output: Option<&str>,
-    dependencies: Vec<&str>,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn run_test(package_name: &str, output: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("cargo-hacspec")?;
     cmd.envs(env::vars());
-    dependencies.iter().for_each(|d| {
-        cmd.arg(format!("--extern={}", d));
-    });
     if let Some(f) = output {
         cmd.arg(format!("-o {}", f));
     }
@@ -22,30 +15,14 @@ fn run_test(
 
 #[test]
 fn run_chacha20_test() -> Result<(), Box<dyn std::error::Error>> {
-    run_test(
-        "hacspec-chacha20",
-        Some("../fstar/Hacspec.Chacha20.fst"),
-        vec![],
-    )?;
-    run_test(
-        "hacspec-chacha20",
-        Some("../easycrypt/Hacspec_Chacha20.ec"),
-        vec![],
-    )
+    run_test("hacspec-chacha20", Some("../fstar/Hacspec.Chacha20.fst"))?;
+    run_test("hacspec-chacha20", Some("../easycrypt/Hacspec_Chacha20.ec"))
 }
 
 #[test]
 fn run_poly1305_test() -> Result<(), Box<dyn std::error::Error>> {
-    run_test(
-        "hacspec-poly1305",
-        Some("../fstar/Hacspec.Poly1305.fst"),
-        vec![],
-    )?;
-    run_test(
-        "hacspec-poly1305",
-        Some("../easycrypt/Hacspec_Poly1305.ec"),
-        vec![],
-    )
+    run_test("hacspec-poly1305", Some("../fstar/Hacspec.Poly1305.fst"))?;
+    run_test("hacspec-poly1305", Some("../easycrypt/Hacspec_Poly1305.ec"))
 }
 
 #[test]
@@ -53,58 +30,45 @@ fn run_chacha20poly1305_test() -> Result<(), Box<dyn std::error::Error>> {
     run_test(
         "hacspec-chacha20poly1305",
         Some("../fstar/Hacspec.Chacha20Poly1305.fst"),
-        vec![],
     )
 }
 
 #[test]
 fn run_ntru_prime_test() -> Result<(), Box<dyn std::error::Error>> {
-    run_test("hacspec-ntru-prime", None, vec![])
+    run_test("hacspec-ntru-prime", None)
 }
 
 #[test]
 fn run_sha3_test() -> Result<(), Box<dyn std::error::Error>> {
-    run_test("hacspec-sha3", None, vec![])
+    run_test("hacspec-sha3", None)
 }
 
 #[test]
 fn run_sha256_test() -> Result<(), Box<dyn std::error::Error>> {
-    run_test("hacspec-sha256", None, vec![])
+    run_test("hacspec-sha256", None)
 }
 
 #[test]
 fn run_p256_test() -> Result<(), Box<dyn std::error::Error>> {
-    run_test("hacspec-p256", None, vec![])
+    run_test("hacspec-p256", None)
 }
 
 #[test]
 fn run_curve25519_test() -> Result<(), Box<dyn std::error::Error>> {
-    run_test("hacspec-curve25519", None, vec![])
+    run_test("hacspec-curve25519", None)
 }
 
 #[test]
 fn run_riot_test() -> Result<(), Box<dyn std::error::Error>> {
-    run_test(
-        "hacspec-riot-bootloader",
-        Some("../fstar/Hacspec.Riot.fst"),
-        vec![],
-    )
+    run_test("hacspec-riot-bootloader", Some("../fstar/Hacspec.Riot.fst"))
 }
 
 #[test]
 fn run_hmac_test() -> Result<(), Box<dyn std::error::Error>> {
-    run_test(
-        "hacspec-hmac",
-        Some("../fstar/Hacspec.Hmac.fst"),
-        vec![],
-    )
+    run_test("hacspec-hmac", Some("../fstar/Hacspec.Hmac.fst"))
 }
 
 #[test]
 fn run_hkdf_test() -> Result<(), Box<dyn std::error::Error>> {
-    run_test(
-        "hacspec-hkdf",
-        Some("../fstar/Hacspec.Hkdf.fst"),
-        vec![],
-    )
+    run_test("hacspec-hkdf", Some("../fstar/Hacspec.Hkdf.fst"))
 }


### PR DESCRIPTION
This adds all dependencies of a crate as `--extern=` to the typechecker. This makes it easier to typecheck more complex specs, especially as long as every file has to be in a different crate.