### PR TITLE
ecdsa p256 sha256

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -15,9 +15,5 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Prepare
-        run: cargo install --path language --verbose
-      - name: Build
-        run: cargo build --verbose
       - name: Typecheck
         run: examples/typecheck_examples.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "examples/hkdf",
     "examples/p256",
     "examples/bls12-381",
+    "examples/ecdsa-p256-sha256",
 ]
 default-members = [
     "lib",
@@ -50,6 +51,7 @@ default-members = [
     "examples/hkdf",
     "examples/p256",
     "examples/bls12-381",
+    "examples/ecdsa-p256-sha256",
 ]
 
 [profile.release]

--- a/examples/curve25519/Cargo.toml
+++ b/examples/curve25519/Cargo.toml
@@ -9,6 +9,3 @@ path = "src/curve25519.rs"
 
 [dependencies]
 hacspec-lib = { path = "../../lib" }
-hacspec-derive = { path = "../../utils/derive" }
-secret_integers = { path = "../../utils/secret-integers" }
-abstract_integers = { path = "../../utils/abstract-integers" }

--- a/examples/ecdsa-p256-sha256/.gitignore
+++ b/examples/ecdsa-p256-sha256/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/examples/ecdsa-p256-sha256/Cargo.toml
+++ b/examples/ecdsa-p256-sha256/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "hacspec-ecdsa-p256-sha256"
+version = "0.1.0"
+authors = ["Franziskus Kiefer <franziskuskiefer@gmail.com>"]
+edition = "2018"
+
+[lib]
+path = "src/ecdsa.rs"
+
+[dependencies]
+hacspec-lib = { path = "../../lib", version = "0.1.0-beta.1" }
+hacspec-p256 = { path = "../p256" }
+hacspec-sha256 = { path = "../sha256" }

--- a/examples/ecdsa-p256-sha256/src/ecdsa.rs
+++ b/examples/ecdsa-p256-sha256/src/ecdsa.rs
@@ -1,0 +1,92 @@
+use hacspec_lib::*;
+use hacspec_p256::*;
+use hacspec_sha256::*;
+
+type PublicKey = Affine;
+type SecretKey = Scalar;
+type Signature = (Scalar, Scalar); // (r, s)
+
+pub fn sign(payload: &ByteSeq, sk: SecretKey, nonce: Scalar) -> (bool, Signature) {
+    let mut success = true;
+    let (b, (k_x, _k_y)) = point_mul_base(nonce);
+    success = success && b;
+    // let (mut success, (x, y)) = k;
+    let r = Scalar::from_byte_seq_be(k_x.to_byte_seq_be());
+    if r.equal(Scalar::ZERO()) {
+        // We should really return here.
+        success = false;
+    }
+    let payload_hash = hash(payload);
+    let payload_hash = Scalar::from_byte_seq_be(payload_hash);
+    let rsk = r * sk;
+    let hash_rsk = payload_hash + rsk;
+    let nonce_inv = nonce.inv();
+    let s = nonce_inv * hash_rsk;
+
+    (success, (r, s))
+}
+
+pub fn verify(payload: &ByteSeq, pk: PublicKey, signature: Signature) -> bool {
+    // signature = (r, s) must be in [1, n-1] because they are Scalars
+    let (r, s) = signature;
+    let mut success = true;
+    let payload_hash = hash(payload);
+    let payload_hash = Scalar::from_byte_seq_be(payload_hash);
+    let s_inv = s.inv();
+
+    // R' = (h * s1) * G + (r * s1) * pubKey
+    let u1 = payload_hash * s_inv;
+    let (b, u1) = point_mul_base(u1);
+    success = success && b;
+
+    let u2 = r * s_inv;
+    let (b, u2) = point_mul(u2, pk);
+    success = success && b;
+    let (b, (x, _y)) = point_add(u1, u2);
+    success = success && b;
+    let x = Scalar::from_byte_seq_be(x.to_byte_seq_be());
+    success && x == r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn self_test() {
+        let sk =
+            Scalar::from_hex("ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550");
+        let pk = (
+            FieldElement::from_hex(
+                "6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296",
+            ),
+            FieldElement::from_hex(
+                "B01CBD1C01E58065711814B583F061E9D431CCA994CEA1313449BF97C840AE0A",
+            ),
+        );
+        let msg = ByteSeq::from_public_slice(b"hacspec ecdsa p256 sha256 self test");
+        let nonce = Scalar::from_be_bytes(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+
+        let (success, signature) = sign(&msg, sk, nonce);
+        assert!(success);
+        assert!(verify(&msg, pk, signature));
+    }
+
+    #[test]
+    fn kat_sign() {
+        let pk = (
+            FieldElement::from_hex(
+                "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
+            ),
+            FieldElement::from_hex(
+                "c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+            ),
+        );
+        let msg = ByteSeq::from_hex("313233343030");
+        let sig = (
+            Scalar::from_hex("2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18"),
+            Scalar::from_hex("b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db"),
+        );
+        assert!(verify(&msg, pk, sig));
+    }
+}

--- a/examples/p256/src/p256.rs
+++ b/examples/p256/src/p256.rs
@@ -83,6 +83,7 @@ fn is_point_at_infinity(p: Jacobian) -> bool {
     z.equal(FieldElement::from_literal(0u128))
 }
 
+#[allow(unused_assignments)]
 pub fn point_add(p: Affine, q: Affine) -> (bool, Affine) {
     // TODO: this is pretty ugly but everything else doesn't work in hacspec yet.
     let (mut success, mut result) = (false, p);

--- a/examples/typecheck_examples.sh
+++ b/examples/typecheck_examples.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
 
-cargo hacspec hacspec-chacha20
-cargo hacspec hacspec-chacha20poly1305
-cargo hacspec hacspec-poly1305
-cargo hacspec hacspec-curve25519
-cargo hacspec hacspec-hkdf
-cargo hacspec hacspec-hmac
-cargo hacspec hacspec-sha256
-cargo hacspec hacspec-ntru-prime
-cargo hacspec hacspec-p256
-cargo hacspec hacspec-riot-bootloader
-cargo hacspec hacspec-sha3
-cargo hacspec hacspec-gimli
-cargo hacspec hacspec-bls12-381
-cargo hacspec hacspec-ecdsa-p256-sha256
+function typecheck {
+  cargo build -p $1
+  cargo hacspec $1
+}
+
+cargo clean
+cargo install --path language
+typecheck hacspec-chacha20
+typecheck hacspec-chacha20poly1305
+typecheck hacspec-poly1305
+typecheck hacspec-curve25519
+typecheck hacspec-hkdf
+typecheck hacspec-hmac
+typecheck hacspec-sha256
+typecheck hacspec-ntru-prime
+typecheck hacspec-p256
+typecheck hacspec-riot-bootloader
+typecheck hacspec-sha3
+typecheck hacspec-gimli
+typecheck hacspec-bls12-381
+typecheck hacspec-ecdsa-p256-sha256

--- a/examples/typecheck_examples.sh
+++ b/examples/typecheck_examples.sh
@@ -1,23 +1,37 @@
 #!/bin/bash
 
+set -e
+
 function typecheck {
+  echo "Typechecking $1 ..."
   cargo build -p $1
-  cargo hacspec $1
+  if [ "$2" == "ec" ];
+  then
+    echo "    extracting EC ..."
+    cargo hacspec -o $1.ec $1
+  else
+    cargo hacspec $1
+  fi
+  if [ "$3" == "fst" ];
+  then
+    echo "    extracting F* ..."
+    cargo hacspec -o $1.fst $1
+  fi
 }
 
 cargo clean
 cargo install --path language
-typecheck hacspec-chacha20
-typecheck hacspec-chacha20poly1305
-typecheck hacspec-poly1305
-typecheck hacspec-curve25519
-typecheck hacspec-hkdf
-typecheck hacspec-hmac
-typecheck hacspec-sha256
-typecheck hacspec-ntru-prime
-typecheck hacspec-p256
-typecheck hacspec-riot-bootloader
-typecheck hacspec-sha3
-typecheck hacspec-gimli
-typecheck hacspec-bls12-381
-typecheck hacspec-ecdsa-p256-sha256
+typecheck hacspec-chacha20             ec      fst
+typecheck hacspec-chacha20poly1305     ec      fst
+typecheck hacspec-poly1305             ec      fst
+typecheck hacspec-curve25519           ec      fst
+typecheck hacspec-hkdf                 ec      fst
+typecheck hacspec-hmac              no-ec      fst
+typecheck hacspec-sha256            no-ec      fst
+typecheck hacspec-ntru-prime           ec      fst
+typecheck hacspec-p256                 ec      fst
+typecheck hacspec-riot-bootloader      ec      fst
+typecheck hacspec-sha3              no-ec      fst
+typecheck hacspec-gimli                ec      fst
+typecheck hacspec-bls12-381         no-ec   no-fst
+typecheck hacspec-ecdsa-p256-sha256 no-ec   no-fst

--- a/examples/typecheck_examples.sh
+++ b/examples/typecheck_examples.sh
@@ -13,3 +13,4 @@ cargo hacspec hacspec-riot-bootloader
 cargo hacspec hacspec-sha3
 cargo hacspec hacspec-gimli
 cargo hacspec hacspec-bls12-381
+cargo hacspec hacspec-ecdsa-p256-sha256

--- a/language/Cargo.toml
+++ b/language/Cargo.toml
@@ -31,18 +31,6 @@ regex = "1.3.9"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"
-hacspec-lib = { path = "../lib" }
-hacspec-chacha20 = { path = "../examples/chacha20" }
-hacspec-poly1305 = { path = "../examples/poly1305" }
-hacspec-chacha20poly1305 = { path = "../examples/chacha20poly1305" }
-hacspec-ntru-prime = { path = "../examples/ntru-prime" }
-hacspec-sha3 = { path = "../examples/sha3" }
-hacspec-sha256 = { path = "../examples/sha256" }
-hacspec-curve25519 = { path = "../examples/curve25519" }
-hacspec-riot-bootloader = { path = "../examples/riot-bootloader" }
-hacspec-hmac = { path = "../examples/hmac" }
-hacspec-hkdf = { path = "../examples/hkdf" }
-hacspec-p256 = { path = "../examples/p256" }
 
 
 [package.metadata.rust-analyzer]

--- a/language/Cargo.toml
+++ b/language/Cargo.toml
@@ -31,7 +31,7 @@ regex = "1.3.9"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"
-
+hacspec-lib = { path = "../lib" }
 
 [package.metadata.rust-analyzer]
 rustc_private=true

--- a/language/src/hir_to_rustspec.rs
+++ b/language/src/hir_to_rustspec.rs
@@ -307,57 +307,102 @@ fn process_fn_id(
     };
 }
 
-fn add_array_type_from_ctor_sig(
-    tcx: &TyCtxt,
-    sig: &PolyFnSig,
-    external_arrays: &mut HashMap<String, BaseTyp>,
-) {
-    let ret = sig.output().skip_binder();
-    match ret.kind() {
+enum SpecialTypeReturn {
+    Array(BaseTyp),
+    NatInt(BaseTyp),
+    RawAbstractInt(BaseTyp),
+    NotSpecial,
+}
+
+fn check_special_type_from_struct_shape(tcx: &TyCtxt, def: &ty::Ty) -> SpecialTypeReturn {
+    match def.kind() {
         TyKind::Adt(adt, substs) => {
             if substs.len() > 0 {
-                return ();
+                return SpecialTypeReturn::NotSpecial;
             }
             if adt.variants.len() != 1 {
-                return ();
+                return SpecialTypeReturn::NotSpecial;
             }
-            for variant in adt.variants.iter() {
-                if variant.fields.len() != 1 {
-                    return ();
+            let variant = adt.variants.iter().next().unwrap();
+            let maybe_abstract_int = match variant.fields.len() {
+                1 => false,
+                3 => true,
+                _ => {
+                    return SpecialTypeReturn::NotSpecial;
                 }
-                for field in variant.fields.iter() {
-                    match tcx.type_of(field.did).kind() {
-                        TyKind::Array(cell_t, size) => {
-                            let (new_cell_t, _) =
-                                match translate_base_typ(tcx, cell_t, &HashMap::new()) {
-                                    Ok(x) => x,
-                                    Err(()) => return (),
-                                };
-                            let new_size = match &size.val {
-                                ConstKind::Value(value) => match value {
-                                    ConstValue::Scalar(scalar) => match scalar {
-                                        Scalar::Int(s) => s.to_bits(s.size()).unwrap() as usize,
-                                        _ => return (),
-                                    },
-                                    _ => return (),
-                                },
-                                _ => return (),
-                            };
-                            let array_typ = BaseTyp::Array(
-                                (ArraySize::Integer(new_size), DUMMY_SP),
-                                Box::new((new_cell_t, DUMMY_SP)),
-                            );
-                            let array_name =
-                                tcx.def_path(adt.did).data.last().unwrap().data.to_string();
-                            external_arrays.insert(array_name, array_typ);
+            };
+            let field = variant.fields.iter().next().unwrap();
+            let field_typ = tcx.type_of(field.did);
+            match &field_typ.kind() {
+                TyKind::Array(cell_t, size) => {
+                    let (new_cell_t, _) = match translate_base_typ(tcx, cell_t, &HashMap::new()) {
+                        Ok(x) => x,
+                        Err(()) => return SpecialTypeReturn::NotSpecial,
+                    };
+                    let new_size = match &size.val {
+                        ConstKind::Value(value) => match value {
+                            ConstValue::Scalar(scalar) => match scalar {
+                                Scalar::Int(s) => Some(s.to_bits(s.size()).unwrap() as usize),
+                                _ => None,
+                            },
+                            _ => None,
+                        },
+                        _ => None,
+                    };
+                    if maybe_abstract_int {
+                        // So here we cannot infer neither the secrecy nor the modulo
+                        // value, nor the size, but its fine for typechecking?
+                        let nat_int_typ = BaseTyp::NaturalInteger(
+                            Secrecy::Secret,
+                            ("unknown".to_string(), DUMMY_SP),
+                            (0, DUMMY_SP),
+                        );
+                        SpecialTypeReturn::RawAbstractInt(nat_int_typ)
+                    } else {
+                        match new_size {
+                            None => SpecialTypeReturn::NotSpecial,
+                            Some(new_size) => {
+                                let array_typ = BaseTyp::Array(
+                                    (ArraySize::Integer(new_size), DUMMY_SP),
+                                    Box::new((new_cell_t, DUMMY_SP)),
+                                );
+                                SpecialTypeReturn::Array(array_typ)
+                            }
                         }
-                        _ => return (),
                     }
                 }
+                _ => {
+                    return match check_special_type_from_struct_shape(tcx, &field_typ) {
+                        SpecialTypeReturn::NotSpecial
+                        | SpecialTypeReturn::NatInt(_)
+                        | SpecialTypeReturn::Array(_) => SpecialTypeReturn::NotSpecial,
+                        SpecialTypeReturn::RawAbstractInt(nat_int_typ) => {
+                            SpecialTypeReturn::NatInt(nat_int_typ)
+                        }
+                    };
+                }
             }
-            ()
         }
-        _ => (),
+        _ => SpecialTypeReturn::NotSpecial,
+    }
+}
+
+fn add_special_type_from_struct_shape(
+    tcx: &TyCtxt,
+    def_id: DefId,
+    def: &ty::Ty,
+    external_arrays: &mut HashMap<String, BaseTyp>,
+    external_nat_ints: &mut HashMap<String, BaseTyp>,
+) {
+    let def_name = tcx.def_path(def_id).data.last().unwrap().data.to_string();
+    match check_special_type_from_struct_shape(tcx, def) {
+        SpecialTypeReturn::Array(array_typ) => {
+            external_arrays.insert(def_name, array_typ);
+        }
+        SpecialTypeReturn::NatInt(nat_int_typ) => {
+            external_nat_ints.insert(def_name, nat_int_typ);
+        }
+        SpecialTypeReturn::NotSpecial | SpecialTypeReturn::RawAbstractInt(_) => {}
     }
 }
 
@@ -365,6 +410,7 @@ pub struct ExternalData {
     pub funcs: HashMap<FnKey, Result<ExternalFuncSig, String>>,
     pub consts: HashMap<String, BaseTyp>,
     pub arrays: HashMap<String, BaseTyp>,
+    pub nat_ints: HashMap<String, BaseTyp>,
     pub ty_aliases: HashMap<String, BaseTyp>,
 }
 
@@ -378,6 +424,7 @@ pub fn retrieve_external_data(
     let mut extern_funcs = HashMap::new();
     let mut extern_consts = HashMap::new();
     let mut extern_arrays = HashMap::new();
+    let mut extern_nat_ints = HashMap::new();
     let mut ty_aliases = HashMap::new();
     let crate_store = tcx.cstore_as_any().downcast_ref::<CStore>().unwrap();
     let mut imported_crates = imported_crates.clone();
@@ -417,6 +464,13 @@ pub fn retrieve_external_data(
                             {
                                 match x.data {
                                     DefPathData::TypeNs(name) => match tcx.def_kind(def_id) {
+                                        DefKind::Struct => add_special_type_from_struct_shape(
+                                            tcx,
+                                            def_id,
+                                            &tcx.type_of(def_id),
+                                            &mut extern_arrays,
+                                            &mut extern_nat_ints,
+                                        ),
                                         DefKind::TyAlias => {
                                             if def_path.data.len() <= 2 {
                                                 let typ = tcx.type_of(def_id);
@@ -460,11 +514,6 @@ pub fn retrieve_external_data(
                                                 Ok(sig) => Ok(sig),
                                                 Err(()) => Err(format!("{}", export_sig)),
                                             };
-                                            add_array_type_from_ctor_sig(
-                                                tcx,
-                                                &export_sig,
-                                                &mut extern_arrays,
-                                            );
                                             let name_segment =
                                                 def_path.data[def_path.data.len() - 2];
                                             match name_segment.data {
@@ -524,6 +573,7 @@ pub fn retrieve_external_data(
         funcs: extern_funcs,
         consts: extern_consts,
         arrays: extern_arrays,
+        nat_ints: extern_nat_ints,
         ty_aliases,
     }
 }

--- a/lib/src/math_integers.rs
+++ b/lib/src/math_integers.rs
@@ -29,6 +29,34 @@ macro_rules! unsigned_public_integer {
     ($name:ident,$n:literal) => {
         abstract_unsigned_public_integer!($name, $n);
 
+        impl $name {
+            #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
+            pub fn from_byte_seq_be<A: SeqTrait<U8>>(s: A) -> $name {
+                $name::from_be_bytes(
+                    s.iter()
+                        .map(|x| U8::declassify(*x))
+                        .collect::<Vec<_>>()
+                        .as_slice(),
+                )
+            }
+
+            #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
+            pub fn from_public_byte_seq_be<A: SeqTrait<u8>>(s: A) -> $name {
+                // XXX: unnecessarily complex
+                $name::from_be_bytes(s.iter().map(|x| *x).collect::<Vec<_>>().as_slice())
+            }
+
+            #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
+            pub fn to_byte_seq_be(self) -> Seq<U8> {
+                Seq::from_vec(
+                    self.to_be_bytes()
+                        .iter()
+                        .map(|x| U8::classify(*x))
+                        .collect::<Vec<U8>>(),
+                )
+            }
+        }
+
         impl NumericCopy for $name {}
         impl UnsignedInteger for $name {}
         impl UnsignedIntegerCopy for $name {}
@@ -796,28 +824,6 @@ macro_rules! nat_mod {
 
         impl $name {
             #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
-            pub fn from_byte_seq_be<A: SeqTrait<U8>>(s: A) -> $name {
-                $name::from_be_bytes(
-                    s.iter()
-                        .map(|x| U8::declassify(*x))
-                        .collect::<Vec<_>>()
-                        .as_slice(),
-                )
-            }
-
-            #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
-            pub fn to_byte_seq_be(self) -> Seq<U8> {
-                Seq::from_vec(
-                    self.to_be_bytes()
-                        .iter()
-                        .map(|x| U8::classify(*x))
-                        .collect::<Vec<U8>>(),
-                )
-            }
-        }
-
-        impl $name {
-            #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
             pub fn from_byte_seq_le<A: SeqTrait<U8>>(s: A) -> $name {
                 $name::from_le_bytes(
                     s.iter()
@@ -1090,17 +1096,17 @@ macro_rules! public_nat_mod {
         impl $name {
             #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
             pub fn from_byte_seq_be<A: SeqTrait<U8>>(s: A) -> $name {
-                $name::from_be_bytes(
+                $base::from_be_bytes(
                     s.iter()
                         .map(|x| U8::declassify(*x))
                         .collect::<Vec<_>>()
                         .as_slice(),
-                )
+                ).into()
             }
 
             #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
             pub fn from_public_byte_seq_be<A: SeqTrait<u8>>(s: A) -> $name {
-                $name::from_be_bytes(s.iter().map(|x| *x).collect::<Vec<_>>().as_slice())
+                $base::from_be_bytes(s.iter().map(|x| *x).collect::<Vec<_>>().as_slice()).into()
             }
 
             #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
@@ -1120,17 +1126,17 @@ macro_rules! public_nat_mod {
 
             #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
             pub fn from_byte_seq_le<A: SeqTrait<U8>>(s: A) -> $name {
-                $name::from_le_bytes(
+                $base::from_le_bytes(
                     s.iter()
                         .map(|x| U8::declassify(*x))
                         .collect::<Vec<_>>()
                         .as_slice(),
-                )
+                ).into()
             }
 
             #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
             pub fn from_public_byte_seq_le<A: SeqTrait<u8>>(s: A) -> $name {
-                $name::from_le_bytes(s.iter().map(|x| *x).collect::<Vec<_>>().as_slice())
+                $base::from_le_bytes(s.iter().map(|x| *x).collect::<Vec<_>>().as_slice()).into()
             }
 
             #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
@@ -1150,7 +1156,7 @@ macro_rules! public_nat_mod {
 
             #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
             pub fn from_secret_literal(x: U128) -> $name {
-                $name::from_literal(U128::declassify(x))
+                $base::from_literal(U128::declassify(x)).into()
             }
         }
 


### PR DESCRIPTION
ECDSA-P256-SHA256

There are still two typechecking errors that look like errors in the typechecker. @denismerigoux do you have an idea what could happen here?

```
error[Hacspec]: the variable r_1920 is not present in the context
  --> /Users/franziskus/repos/hacspec/examples/ecdsa-p256-sha256/src/ecdsa.rs:21:15
   |
21 |     let rsk = r * sk;
   |               ^

error[Hacspec]: operation not available for type Scalar
  --> /Users/franziskus/repos/hacspec/examples/ecdsa-p256-sha256/src/ecdsa.rs:38:14
   |
38 |     let u1 = payload_hash * s_inv;
   |              ^^^^^^^^^^^^^^^^^^^^

```