### PR TITLE
hacspec_unsafe attribute

### DIFF
--- a/utils/attributes/Cargo.toml
+++ b/utils/attributes/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0"
 hacspec-util = { path = "../util", version = "0.1.0-beta.1" }
 
 [features]
-default = []
+default = [ "hacspec_unsafe" ]
 print_attributes = []
 update_allowlist = [ "print_attributes" ]
+hacspec_unsafe = []

--- a/utils/attributes/Readme.md
+++ b/utils/attributes/Readme.md
@@ -4,7 +4,7 @@
 [![Docs](https://img.shields.io/badge/docs-master-blue.svg?logo=rust)](https://hacspec.github.io/hacspec/hacspec_attributes/index.html)
 [![Build & Test Status][build-image]][build-link]
 
-This crate holds implements hacspec attributes used in the [hacspec library](../../lib/).
+This crate holds implements hacspec attributes used only in the [hacspec library](../../lib/) as well as attributes that can be used in hacspecs.
 
 ## Features
 ### hacspec_unsafe

--- a/utils/attributes/Readme.md
+++ b/utils/attributes/Readme.md
@@ -6,7 +6,18 @@
 
 This crate holds implements hacspec attributes used in the [hacspec library](../../lib/).
 
-**It should never be necessary to use this outside of the hacspec repository.**
+## Features
+### hacspec_unsafe
+This is a **default feature** that enables the `#[hacspec_unsafe]` attribute.
+The `#[hacspec_unsafe]` attribute can be used to call Rust code from hacspec.
+A function with the `#[hacspec_unsafe]` attribute must have a signature within hacspec but can use Rust in its body.
+A function with `#[hacspec_unsafe(outside)]` is completely ignored by the hacspec typechecker.
+
+### print_attributes
+This feature is used within the hacspec library to mark functions according to their language affiliation.
+
+### update_allowlist
+This feature is used within the hacspec library.
 
 [//]: # (badges)
 

--- a/utils/attributes/src/lib.rs
+++ b/utils/attributes/src/lib.rs
@@ -1,5 +1,11 @@
-#![cfg_attr(feature = "print_attributes", feature(proc_macro_diagnostic))]
-#![cfg_attr(feature = "print_attributes", feature(proc_macro_span))]
+#![cfg_attr(
+    any(feature = "print_attributes", feature = "hacspec_unsafe"),
+    feature(proc_macro_diagnostic)
+)]
+#![cfg_attr(
+    any(feature = "print_attributes", feature = "hacspec_unsafe"),
+    feature(proc_macro_span)
+)]
 
 extern crate ansi_term;
 extern crate hacspec_util;
@@ -12,7 +18,9 @@ extern crate syn;
 use ansi_term::Colour::{Blue, Green, Purple, Yellow};
 #[cfg(feature = "print_attributes")]
 use hacspec_util::{syn_sig_to_reduced, Signature};
-#[cfg(feature = "print_attributes")]
+#[cfg(feature = "hacspec_unsafe")]
+use proc_macro::TokenTree::Ident;
+#[cfg(any(feature = "print_attributes", feature = "hacspec_unsafe"))]
 use proc_macro::*;
 #[cfg(feature = "print_attributes")]
 use quote::quote;
@@ -20,23 +28,22 @@ use quote::quote;
 use std::collections::{HashMap, HashSet};
 #[cfg(feature = "print_attributes")]
 use std::fs::OpenOptions;
-#[cfg(feature = "print_attributes")]
+#[cfg(any(feature = "print_attributes", feature = "hacspec_unsafe"))]
 use syn::{parse_macro_input, spanned::Spanned, ItemFn};
 #[cfg(feature = "print_attributes")]
 const ITEM_LIST_LOCATION: &str = "./allowed_item_list.json";
 
 macro_rules! declare_attribute {
     ($id:ident, $key: expr, $msg: expr, $doc:tt, $allowed_item: expr) => {
-        #[cfg(feature="print_attributes")]
+        #[cfg(feature = "print_attributes")]
         #[doc=$doc]
         #[proc_macro_attribute]
         pub fn $id(attr: TokenStream, item: TokenStream) -> TokenStream {
             let item_copy = proc_macro2::TokenStream::from(item.clone());
             let func = parse_macro_input!(item as ItemFn);
             let mut attr_args_iter = attr.into_iter();
-            let _impl_type_name: Option<String> = attr_args_iter.next().map(|arg| {
-                format!("{}", arg)
-            });
+            let _impl_type_name: Option<String> =
+                attr_args_iter.next().map(|arg| format!("{}", arg));
             let _is_generic: bool = attr_args_iter.next().map_or(false, |_| {
                 let _ = attr_args_iter.next().expect("Error 7");
                 true
@@ -48,13 +55,14 @@ macro_rules! declare_attribute {
                         .open(ITEM_LIST_LOCATION)
                         .expect("Error 1");
                     let key_s = String::from($key);
-                    let mut item_list : HashMap<String, HashSet<Signature>> = serde_json::from_reader(&file).unwrap();
+                    let mut item_list: HashMap<String, HashSet<Signature>> =
+                        serde_json::from_reader(&file).unwrap();
                     let item_list_type = match item_list.get_mut(&key_s) {
                         None => {
-                          item_list.insert(key_s.clone(), HashSet::new());
-                          item_list.get_mut(&key_s).expect("Error 2")
+                            item_list.insert(key_s.clone(), HashSet::new());
+                            item_list.get_mut(&key_s).expect("Error 2")
                         }
-                        Some(items) => items
+                        Some(items) => items,
                     };
                     item_list_type.insert(syn_sig_to_reduced(&func.sig));
                 }
@@ -79,9 +87,9 @@ macro_rules! declare_attribute {
             }
             let doc_msg = format!("_{}_\n", $doc);
             let output = quote! {
-                #[doc=#doc_msg]
-                #item_copy
-             };
+               #[doc=#doc_msg]
+               #item_copy
+            };
             output.into()
         }
     };
@@ -109,3 +117,39 @@ declare_attribute!(
     "Function that is not part of the language but is offered as a helper for tests, etc.",
     false
 );
+
+#[cfg(feature = "hacspec_unsafe")]
+#[proc_macro_attribute]
+pub fn hacspec_unsafe(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item_copy = item.clone();
+    let func = parse_macro_input!(item_copy as ItemFn);
+    let outside = match attr.into_iter().next() {
+        Some(Ident(arg)) => {
+            if arg.to_string() == "outside" {
+                true
+            } else {
+                false
+            }
+        }
+        Some(_) | None => false,
+    };
+    let msg = if outside {
+        format!("function outside of hacspec")
+    } else {
+        format!("unsafe hacspec function")
+    };
+    Diagnostic::new(
+        Level::Note,
+        format!("{}: {} {}", msg, format!("{}", func.sig.ident), {
+            let file = func.sig.span().unwrap().source_file().path();
+            let start = func.sig.span().start();
+            format!(
+                "in {}:{}",
+                file.to_str().unwrap(),
+                format!("{}", start.line)
+            )
+        }),
+    )
+    .emit();
+    item
+}

--- a/utils/attributes/tests/hacspec_file.rs
+++ b/utils/attributes/tests/hacspec_file.rs
@@ -1,0 +1,10 @@
+
+use hacspec_attributes::hacspec_unsafe;
+
+#[hacspec_unsafe]
+#[allow(dead_code)]
+fn test_unsafe_hacspec() {}
+
+#[hacspec_unsafe(outside)]
+#[allow(dead_code)]
+fn test_outside_hacspec() {}


### PR DESCRIPTION
This adds the attribute for #104.
Note that this PR does not handle tha attribute in the compiler yet.