### PR TITLE
Allow question marks at the end of reassignments and array updates

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -5,6 +5,7 @@ on: [push, pull_request, release]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       matrix:
         os:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -5,6 +5,7 @@ on: [push, pull_request, release]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       matrix:
         os:

--- a/fstar/Hacspec.Chacha20.fst
+++ b/fstar/Hacspec.Chacha20.fst
@@ -100,16 +100,11 @@ let chacha20_encrypt_block (st0_39: state) (ctr_40: uint32) (plain_41: block) : 
 let chacha20_encrypt_last
       (st0_45: state)
       (ctr_46: uint32)
-      (plain_47: byte_seq{(**) Seq.length plain_47 <= 64})
+      (plain_47: byte_seq{(**)Seq.length plain_47 <= 64})
     :
     byte_seq =
   let b_48 = array_new_ (secret (pub_u8 0x0)) (64) in
-  let b_48 =
-    array_update (b_48)
-      (usize 0)
-      (**) #(Seq.length plain_47)
-      (plain_47)
-  in
+  let b_48 = array_update (b_48) (usize 0) (plain_47) in
   let b_48 = chacha20_encrypt_block (st0_45) (ctr_46) (b_48) in
   array_slice (b_48) (usize 0) (seq_len (plain_47))
 

--- a/fstar/Hacspec.Lib.fst
+++ b/fstar/Hacspec.Lib.fst
@@ -210,8 +210,7 @@ let array_update
   (#len: uint_size)
   (s: lseq a len)
   (start: uint_size)
-  (#input_len: uint_size{start + input_len <= len})
-  (input: lseq a input_len)
+  (input: seq a {start + Seq.length input <= len})
     : lseq a len
   =
   LSeq.update_sub #a #(LSeq.length s) s start (LSeq.length input) input

--- a/fstar/Hacspec.Lib.fst
+++ b/fstar/Hacspec.Lib.fst
@@ -173,6 +173,13 @@ let seq_len (#a: Type) (s: seq a) : nat = Seq.length s
 let seq_new_ (#a: Type) (init:a) (len: uint_size) : lseq a len =
   Seq.create len init
 
+let seq_index (#a: Type) (s: seq a) (i: uint_size{i < seq_len s}) : a =
+  Seq.index s i
+
+let seq_upd (#a: Type) (s: seq a) (i: uint_size{i < seq_len s}) (new_v: a)
+    : (s':seq a{seq_len s' = seq_len s})  =
+  Seq.upd s i new_v
+
 let array_from_list
   (#a: Type)
   (l: list a{List.Tot.length l <= max_size_t})

--- a/fstar/Hacspec.Poly1305.fst
+++ b/fstar/Hacspec.Poly1305.fst
@@ -115,3 +115,4 @@ let poly1305 (m_39: byte_seq) (key_40: poly_key) : tag =
   let st_41 = poly1305_init (key_40) in
   let st_41 = poly1305_update (m_39) (st_41) in
   poly1305_finish (st_41)
+

--- a/fstar/Hacspec.Riot.fst
+++ b/fstar/Hacspec.Riot.fst
@@ -35,13 +35,7 @@ let update_fletcher (f_3: fletcher) (data_4: seq pub_uint16) : fletcher =
               (chunk_len_9)
               (fun j_13 (intermediate_a_11, intermediate_b_12) ->
                   let intermediate_a_11 =
-                    (intermediate_a_11) +.
-                    (cast U32
-                        PUB
-                        (array_index #_
-                            (**) #(Seq.length chunk_10)
-                            (chunk_10)
-                            (j_13)))
+                    (intermediate_a_11) +. (cast U32 PUB (seq_index (chunk_10) (j_13)))
                   in
                   let intermediate_b_12 = (intermediate_b_12) +. (intermediate_a_11) in
                   (intermediate_a_11, intermediate_b_12))
@@ -75,17 +69,17 @@ let header_as_u16_slice (h_17: header) : seq pub_uint16 =
   let u16_seq_28 =
     foldi (usize 0)
       (usize 3)
-      (fun i_29 u16_seq_28 ->
+      (fun i_29 (u16_seq_28: (**) lseq pub_uint16 6) ->
           let u16_word_30 =
             array_from_seq (2) (seq_slice (u8_seq_27) ((i_29) * (usize 4)) (usize 2))
           in
           let u16_value_31 = u16_from_be_bytes (u16_word_30) in
-          let u16_seq_28 = array_upd u16_seq_28 (((usize 2) * (i_29)) + (usize 1)) (u16_value_31) in
+          let u16_seq_28 = seq_upd u16_seq_28 (((usize 2) * (i_29)) + (usize 1)) (u16_value_31) in
           let u16_word_32 =
             array_from_seq (2) (seq_slice (u8_seq_27) (((i_29) * (usize 4)) + (usize 2)) (usize 2))
           in
           let u16_value_33 = u16_from_be_bytes (u16_word_32) in
-          let u16_seq_28 = array_upd u16_seq_28 ((usize 2) * (i_29)) (u16_value_33) in
+          let u16_seq_28 = seq_upd u16_seq_28 ((usize 2) * (i_29)) (u16_value_33) in
           (u16_seq_28))
       (u16_seq_28)
   in
@@ -116,12 +110,7 @@ let choose_image (images_44: seq header) : (bool & pub_uint32) =
     foldi (usize 0)
       (seq_len (images_44))
       (fun i_47 (image_45, image_found_46) ->
-          let header_48 =
-            array_index #_
-              (**) #(Seq.length images_44)
-              (images_44)
-              (i_47)
-          in
+          let header_48 = seq_index (images_44) (i_47) in
           let magic_number_49, seq_number_50, start_addr_51, checksum_52 = header_48 in
           let image_45, image_found_46 =
             if is_valid_header ((magic_number_49, seq_number_50, start_addr_51, checksum_52))

--- a/language/language-tests/question_mark.rs
+++ b/language/language-tests/question_mark.rs
@@ -19,12 +19,25 @@ pub fn fizzbaz() -> Result<u64, U8> {
     Result::<u64, U8>::Ok(x + y)
 }
 
+pub fn fizzbazbaz() -> Result<u64, U8> {
+    let mut x = foo(false)?;
+    let mut y = foo(true)?;
+    x = x + y;
+    y = foo(false)?;
+    Result::<u64, U8>::Ok(x + y)
+}
+
+pub fn fizzbazbazbar(mut s: Seq<u64>) -> Result<u64, U8> {
+    let y = foo(false)?;
+    s[0] = foo(true)?;
+    Result::<u64, U8>::Ok(s[0] + y)
+}
+
 pub fn baz() -> Result<u32, U8> {
     let x = foo(false)?;
     let mut out = 0u32;
     if true || false {
-        let y = foo(true)?;
-        out = y as u32 + 1u32;
+        let _y = foo(true)?;
         foo(false || true)?;
     } else {
         foo(false && true)?;
@@ -34,7 +47,7 @@ pub fn baz() -> Result<u32, U8> {
 }
 
 pub fn fizzbar() -> Result<u32, U8> {
-    let x = foo(false)?;
+    let _x = foo(false)?;
     let mut out = 0u32;
     for i in 0..200 {
         let y = foo(true)?;

--- a/language/src/ast_to_rustspec.rs
+++ b/language/src/ast_to_rustspec.rs
@@ -926,6 +926,7 @@ fn translate_expr(
                                             r_index?,
                                             r_e,
                                             r_e_question_mark,
+                                            None,
                                         )),
                                         e.span.into(),
                                     ))
@@ -1085,6 +1086,7 @@ fn translate_expr(
                                 ExprTranslationResult::TransExpr(Expression::ArrayIndex(
                                     id,
                                     Box::new((r_e2, r_e2_span)),
+                                    None,
                                 )),
                                 e.span.into(),
                             )),

--- a/language/src/name_resolution.rs
+++ b/language/src/name_resolution.rs
@@ -218,11 +218,11 @@ fn resolve_expression(
             ))
         }
         Expression::Lit(_) => Ok((e, e_span)),
-        Expression::ArrayIndex(x, e1) => {
+        Expression::ArrayIndex(x, e1, typ) => {
             let new_x = find_ident(sess, &x, name_context, top_level_ctx)?;
             let new_e1 = resolve_expression(sess, *e1, name_context, top_level_ctx)?;
             Ok((
-                Expression::ArrayIndex((new_x, x.1), Box::new(new_e1)),
+                Expression::ArrayIndex((new_x, x.1), Box::new(new_e1), typ),
                 e_span,
             ))
         }
@@ -341,7 +341,7 @@ fn resolve_statement(
                 resolve_expression(sess, (e, s_span.clone()), &name_context, top_level_ctx)?;
             Ok(((Statement::ReturnExp(new_e.0), s_span), name_context))
         }
-        Statement::ArrayUpdate(var, index, e, question_mark) => {
+        Statement::ArrayUpdate(var, index, e, question_mark, typ) => {
             let new_var = find_ident(sess, &var, &name_context, top_level_ctx)?;
             let new_index = resolve_expression(sess, index, &name_context, top_level_ctx)?;
             let new_e = resolve_expression(sess, e, &name_context, top_level_ctx)?;
@@ -352,6 +352,7 @@ fn resolve_statement(
                         new_index,
                         new_e,
                         question_mark,
+                        typ,
                     ),
                     s_span,
                 ),

--- a/language/src/name_resolution.rs
+++ b/language/src/name_resolution.rs
@@ -341,24 +341,29 @@ fn resolve_statement(
                 resolve_expression(sess, (e, s_span.clone()), &name_context, top_level_ctx)?;
             Ok(((Statement::ReturnExp(new_e.0), s_span), name_context))
         }
-        Statement::ArrayUpdate(var, index, e) => {
+        Statement::ArrayUpdate(var, index, e, question_mark) => {
             let new_var = find_ident(sess, &var, &name_context, top_level_ctx)?;
             let new_index = resolve_expression(sess, index, &name_context, top_level_ctx)?;
             let new_e = resolve_expression(sess, e, &name_context, top_level_ctx)?;
             Ok((
                 (
-                    Statement::ArrayUpdate((new_var, var.1.clone()), new_index, new_e),
+                    Statement::ArrayUpdate(
+                        (new_var, var.1.clone()),
+                        new_index,
+                        new_e,
+                        question_mark,
+                    ),
                     s_span,
                 ),
                 name_context,
             ))
         }
-        Statement::Reassignment(var, e) => {
+        Statement::Reassignment(var, e, question_mark) => {
             let new_var = find_ident(sess, &var, &name_context, top_level_ctx)?;
             let new_e = resolve_expression(sess, e, &name_context, top_level_ctx)?;
             Ok((
                 (
-                    Statement::Reassignment((new_var, var.1.clone()), new_e),
+                    Statement::Reassignment((new_var, var.1.clone()), new_e, question_mark),
                     s_span,
                 ),
                 name_context,

--- a/language/src/rustspec.rs
+++ b/language/src/rustspec.rs
@@ -382,7 +382,11 @@ pub enum Statement {
         Spanned<Expression>,  // Binded expr
         bool,                 // Presence of a question mark at the end
     ),
-    Reassignment(Spanned<Ident>, Spanned<Expression>),
+    Reassignment(
+        Spanned<Ident>,      // Variable reassigned
+        Spanned<Expression>, // New value
+        bool,                // Presence of a question mark at the end
+    ),
     Conditional(
         Spanned<Expression>,        // Condition
         Spanned<Block>,             // Then block
@@ -395,7 +399,12 @@ pub enum Statement {
         Spanned<Expression>, // Upper bound
         Spanned<Block>,      // Loop body
     ),
-    ArrayUpdate(Spanned<Ident>, Spanned<Expression>, Spanned<Expression>),
+    ArrayUpdate(
+        Spanned<Ident>,      // Array variable
+        Spanned<Expression>, // Index value
+        Spanned<Expression>, // Cell value
+        bool,                // Presence of a question mark at the end of the cell value expression
+    ),
     ReturnExp(Expression),
 }
 

--- a/language/src/rustspec.rs
+++ b/language/src/rustspec.rs
@@ -344,7 +344,11 @@ pub enum Expression {
         )>,
     ),
     Lit(Literal),
-    ArrayIndex(Spanned<Ident>, Box<Spanned<Expression>>),
+    ArrayIndex(
+        Spanned<Ident>,           // Array variable
+        Box<Spanned<Expression>>, // Index
+        Fillable<Typ>,            // Type of the array
+    ),
     NewArray(
         Spanned<TopLevelIdent>,   // Name of array type
         Option<BaseTyp>,          // Type of cells
@@ -404,6 +408,7 @@ pub enum Statement {
         Spanned<Expression>, // Index value
         Spanned<Expression>, // Cell value
         bool,                // Presence of a question mark at the end of the cell value expression
+        Fillable<Typ>,       // Type of the array
     ),
     ReturnExp(Expression),
 }

--- a/language/src/rustspec_to_easycrypt.rs
+++ b/language/src/rustspec_to_easycrypt.rs
@@ -750,7 +750,7 @@ fn translate_expression<'a>(e: Expression, top_ctx: &'a TopLevelContext) -> RcDo
                     RcDoc::space().append(make_paren(translate_expression(arg, top_ctx)))
                 })))
         }
-        Expression::ArrayIndex(x, e2) => {
+        Expression::ArrayIndex(x, e2, _typ) => {
             let e2 = e2.0;
             translate_ident(x.0.clone())
                 .append(RcDoc::as_string("."))
@@ -855,7 +855,7 @@ fn translate_statement<'a>(s: &'a Statement, top_ctx: &'a TopLevelContext) -> Rc
             None,
             translate_expression(e1.clone(), top_ctx),
         ),
-        Statement::ArrayUpdate((x, _), (e1, _), (e2, _), _question_mark) => make_let_binding(
+        Statement::ArrayUpdate((x, _), (e1, _), (e2, _), _question_mark, _typ) => make_let_binding(
             translate_ident(x.clone()),
             None,
             translate_ident(x.clone())

--- a/language/src/rustspec_to_easycrypt.rs
+++ b/language/src/rustspec_to_easycrypt.rs
@@ -850,12 +850,12 @@ fn translate_statement<'a>(s: &'a Statement, top_ctx: &'a TopLevelContext) -> Rc
             typ.as_ref().map(|(typ, _)| translate_typ(typ)),
             translate_expression(expr.clone(), top_ctx),
         ),
-        Statement::Reassignment((x, _), (e1, _)) => make_let_binding(
+        Statement::Reassignment((x, _), (e1, _), _question_mark) => make_let_binding(
             translate_ident(x.clone()),
             None,
             translate_expression(e1.clone(), top_ctx),
         ),
-        Statement::ArrayUpdate((x, _), (e1, _), (e2, _)) => make_let_binding(
+        Statement::ArrayUpdate((x, _), (e1, _), (e2, _), _question_mark) => make_let_binding(
             translate_ident(x.clone()),
             None,
             translate_ident(x.clone())

--- a/language/src/typechecker.rs
+++ b/language/src/typechecker.rs
@@ -114,7 +114,7 @@ fn is_copy(t: &BaseTyp, top_ctxt: &TopLevelContext) -> bool {
     }
 }
 
-pub fn is_array(
+fn is_array(
     sess: &Session,
     t: &Typ,
     top_ctxt: &TopLevelContext,
@@ -1902,7 +1902,7 @@ fn var_set_to_tuple(vars: &VarSet, span: &RustspecSpan) -> Statement {
     })
 }
 
-pub fn dealias_type(ty: BaseTyp, top_level_context: &TopLevelContext) -> BaseTyp {
+fn dealias_type(ty: BaseTyp, top_level_context: &TopLevelContext) -> BaseTyp {
     match &ty {
         BaseTyp::Named((name, _), None) => match top_level_context.typ_dict.get(name) {
             Some((((Borrowing::Consumed, _), (aliased_ty, _)), DictEntry::Alias)) => {

--- a/language/src/typechecker.rs
+++ b/language/src/typechecker.rs
@@ -114,7 +114,7 @@ fn is_copy(t: &BaseTyp, top_ctxt: &TopLevelContext) -> bool {
     }
 }
 
-fn is_array(
+pub fn is_array(
     sess: &Session,
     t: &Typ,
     top_ctxt: &TopLevelContext,
@@ -1390,7 +1390,7 @@ fn typecheck_expression(
                 var_context,
             ))
         }
-        Expression::ArrayIndex((x, x_span), e2) => {
+        Expression::ArrayIndex((x, x_span), e2, _) => {
             let t1 = match find_typ(&x, var_context, top_level_context) {
                 None => {
                     sess.span_rustspec_err(
@@ -1414,6 +1414,7 @@ fn typecheck_expression(
                     Expression::ArrayIndex(
                         (x.clone(), x_span.clone()),
                         Box::new((new_e2, e2.1.clone())),
+                        Some(t1.clone()),
                     ),
                     (
                         (Borrowing::Consumed, (t1.0).1),
@@ -1901,7 +1902,7 @@ fn var_set_to_tuple(vars: &VarSet, span: &RustspecSpan) -> Statement {
     })
 }
 
-fn dealias_type(ty: BaseTyp, top_level_context: &TopLevelContext) -> BaseTyp {
+pub fn dealias_type(ty: BaseTyp, top_level_context: &TopLevelContext) -> BaseTyp {
     match &ty {
         BaseTyp::Named((name, _), None) => match top_level_context.typ_dict.get(name) {
             Some((((Borrowing::Consumed, _), (aliased_ty, _)), DictEntry::Alias)) => {
@@ -2108,7 +2109,7 @@ fn typecheck_statement(
                 })),
             ))
         }
-        Statement::ArrayUpdate((x, x_span), e1, e2, question_mark) => {
+        Statement::ArrayUpdate((x, x_span), e1, e2, question_mark, _) => {
             let (new_e1, e1_t, var_context) =
                 typecheck_expression(sess, &e1, top_level_context, var_context)?;
             let (new_e2, e2_t, var_context) =
@@ -2166,6 +2167,7 @@ fn typecheck_statement(
                     (new_e1, e1.1.clone()),
                     (new_e2, e2.1.clone()),
                     *question_mark,
+                    Some(x_typ),
                 ),
                 ((Borrowing::Consumed, s_span), (BaseTyp::Unit, s_span)),
                 var_context,


### PR DESCRIPTION
* [x] Allow question marks at the end of reassignments and array updates
* [x] Replace `bind_ok` with explicit `match ... with` in F* code generation
* [x] Fixed bug in F* generation