### PR TITLE
Drop Copy requirement for Seq

### DIFF
--- a/lib/src/seq.rs
+++ b/lib/src/seq.rs
@@ -12,19 +12,19 @@ macro_rules! declare_seq {
     ($name:ident, $constraint:ident) => {
         /// Variable length byte arrays.
         #[derive(Debug, Clone, Default)]
-        pub struct $name<T: Copy + Default + $constraint> {
+        pub struct $name<T: Default + $constraint> {
             pub(crate) b: Vec<T>,
         }
-        declare_seq_with_contents_constraints_impl!($name, Copy + Default + $constraint);
+        declare_seq_with_contents_constraints_impl!($name, Clone + Default + $constraint);
     };
     ($name:ident) => {
         /// Variable length byte arrays.
         #[derive(Debug, Clone, Default)]
-        pub struct $name<T: Copy + Default> {
+        pub struct $name<T: Default> {
             pub(crate) b: Vec<T>,
         }
 
-        declare_seq_with_contents_constraints_impl!($name, Copy + Default);
+        declare_seq_with_contents_constraints_impl!($name, Clone + Default);
     };
 }
 
@@ -253,7 +253,7 @@ macro_rules! declare_seq_with_contents_constraints_impl {
                 debug_assert!(self.len() >= start_out + len, "{} < {} + {}", self.len(), start_out, len);
                 debug_assert!(v.len() >= start_in + len, "{} < {} + {}", v.len(), start_in, len);
                 for i in 0..len {
-                    self[start_out + i] = v[start_in + i];
+                    self[start_out + i] = v[start_in + i].clone();
                 }
                 self
             }
@@ -358,7 +358,7 @@ macro_rules! declare_seq_with_contents_constraints_impl {
             pub fn from_seq<U: SeqTrait<T>>(x: &U) -> $name<T> {
                 let mut tmp = $name::new(x.len());
                 for i in 0..x.len() {
-                    tmp[i] = x[i];
+                    tmp[i] = x[i].clone();
                 }
                 tmp
             }

--- a/lib/src/traits.rs
+++ b/lib/src/traits.rs
@@ -5,7 +5,7 @@
 use crate::prelude::*;
 
 /// Common trait for all byte arrays and sequences.
-pub trait SeqTrait<T: Copy>:
+pub trait SeqTrait<T: Clone>:
     Index<usize, Output = T> + IndexMut<usize, Output = T> + Sized
 {
     fn len(&self) -> usize;


### PR DESCRIPTION
Elements in a `Seq` had to be `Copy` for some reason. This is not necessary and is being removed here.