### PR TITLE
Add push function to Seq

### DIFF
--- a/lib/src/seq.rs
+++ b/lib/src/seq.rs
@@ -123,6 +123,20 @@ macro_rules! declare_seq_with_contents_constraints_impl {
             }
 
             #[cfg_attr(feature="use_attributes", in_hacspec)]
+            pub fn push(&self, next: &T) -> Self {
+                let mut out = Self::new(self.len() + 1);
+                out = out.update_start(self);
+                out[self.len()] = next.clone();
+                out
+            }
+
+            #[cfg_attr(feature="use_attributes", in_hacspec)]
+            pub fn push_owned(mut self, next: T) -> Self {
+                self.b.push(next);
+                self
+            }
+
+            #[cfg_attr(feature="use_attributes", in_hacspec)]
             pub fn from_slice_range<A: SeqTrait<T>>(input: &A, r: Range<usize>) -> Self {
                 Self::from_slice(input, r.start, r.end - r.start)
             }


### PR DESCRIPTION
Right now in order to append an element to a sequence it is necessary to create a new temporary sequence and then concatenate the two sequences. This is cumbersome and unnecessary. Instead `Seq` needs to get a function `pub fn push(&self, next: &T) -> Self` and `pub fn push_owned(mut self, mut next: T) -> Self`.
These need adding to the F* and Coq libraries.