### PR TITLE
Remove recursive function from bls12-381

### DIFF
--- a/coq/src/Bls.v
+++ b/coq/src/Bls.v
@@ -1,3 +1,4 @@
+(** This file was automatically generated using Hacspec **)
 Require Import Lib MachineIntegers.
 From Coq Require Import ZArith.
 Import List.ListNotations.
@@ -26,13 +27,6 @@ Instance show_scalar : Show (scalar) := Build_Show (scalar) (fun x => show (GZnZ
 Definition g_scalar : G (scalar) := @bindGen Z (scalar) (arbitrary) (fun x => returnGen (@Z_in_nat_mod _ x)).
 Instance gen_scalar : Gen (scalar) := Build_Gen scalar g_scalar.
 
-
-Definition most_significant_bit (m_0 : scalar) (n_1 : uint_size) : uint_size :=
-  if (((n_1) >.? (usize 0)) && (negb (nat_mod_bit (m_0) (n_1)))):bool then (
-    most_significant_bit (m_0) ((n_1) - (usize 1))) else (n_1).
-  
-  QuickChick (
-    forAll g_scalar (fun m_0 : scalar =>forAll g_uint_size (fun n_1 : uint_size =>most_significant_bit m_0) n_1)).
 
 Notation "'g1'" := ((fp × fp × bool)) : hacspec_scope.
 Instance show_g1 : Show (g1) :=
@@ -100,580 +94,474 @@ bindGen arbitrary (fun x0 : fp6 =>
 Instance gen_fp12 : Gen (fp12) := Build_Gen fp12 g_fp12.
 
 
-Definition fp2fromfp (n_2 : fp) : fp2 :=
-  (n_2, nat_mod_zero ).
-  
-  QuickChick (forAll g_fp (fun n_2 : fp =>fp2fromfp n_2)).
+Definition fp2fromfp (n_0 : fp) : fp2 :=
+  (n_0, nat_mod_zero ).
 
 Definition fp2zero  : fp2 :=
   fp2fromfp (nat_mod_zero ).
-  
-  QuickChick (fp2zero).
 
-Definition fp2neg (n_3 : fp2) : fp2 :=
-  let '(n1_4, n2_5) :=
-    n_3 in 
-  ((nat_mod_zero ) -% (n1_4), (nat_mod_zero ) -% (n2_5)).
-  
-  QuickChick (forAll g_fp2 (fun n_3 : fp2 =>fp2neg n_3)).
+Definition fp2neg (n_1 : fp2) : fp2 :=
+  let '(n1_2, n2_3) :=
+    n_1 in 
+  ((nat_mod_zero ) -% (n1_2), (nat_mod_zero ) -% (n2_3)).
 
-Definition fp2add (n_6 : fp2) (m_7 : fp2) : fp2 :=
-  let '(n1_8, n2_9) :=
-    n_6 in 
-  let '(m1_10, m2_11) :=
-    m_7 in 
-  ((n1_8) +% (m1_10), (n2_9) +% (m2_11)).
-  
-  QuickChick (
-    forAll g_fp2 (fun n_6 : fp2 =>forAll g_fp2 (fun m_7 : fp2 =>fp2add n_6) m_7)).
+Definition fp2add (n_4 : fp2) (m_5 : fp2) : fp2 :=
+  let '(n1_6, n2_7) :=
+    n_4 in 
+  let '(m1_8, m2_9) :=
+    m_5 in 
+  ((n1_6) +% (m1_8), (n2_7) +% (m2_9)).
 
-Definition fp2sub (n_12 : fp2) (m_13 : fp2) : fp2 :=
-  fp2add (n_12) (fp2neg (m_13)).
-  
-  QuickChick (
-    forAll g_fp2 (fun n_12 : fp2 =>forAll g_fp2 (fun m_13 : fp2 =>fp2sub n_12) m_13)).
+Definition fp2sub (n_10 : fp2) (m_11 : fp2) : fp2 :=
+  fp2add (n_10) (fp2neg (m_11)).
 
-Definition fp2mul (n_14 : fp2) (m_15 : fp2) : fp2 :=
-  let '(n1_16, n2_17) :=
-    n_14 in 
-  let '(m1_18, m2_19) :=
-    m_15 in 
-  let x1_20 :=
-    ((n1_16) *% (m1_18)) -% ((n2_17) *% (m2_19)) in 
-  let x2_21 :=
-    ((n1_16) *% (m2_19)) +% ((n2_17) *% (m1_18)) in 
-  (x1_20, x2_21).
-  
-  QuickChick (
-    forAll g_fp2 (fun n_14 : fp2 =>forAll g_fp2 (fun m_15 : fp2 =>fp2mul n_14) m_15)).
+Definition fp2mul (n_12 : fp2) (m_13 : fp2) : fp2 :=
+  let '(n1_14, n2_15) :=
+    n_12 in 
+  let '(m1_16, m2_17) :=
+    m_13 in 
+  let x1_18 :=
+    ((n1_14) *% (m1_16)) -% ((n2_15) *% (m2_17)) in 
+  let x2_19 :=
+    ((n1_14) *% (m2_17)) +% ((n2_15) *% (m1_16)) in 
+  (x1_18, x2_19).
 
-Definition fp2inv (n_22 : fp2) : fp2 :=
-  let '(n1_23, n2_24) :=
-    n_22 in 
-  let t0_25 :=
-    ((n1_23) *% (n1_23)) +% ((n2_24) *% (n2_24)) in 
-  let t1_26 :=
-    nat_mod_inv (t0_25) in 
-  let x1_27 :=
-    (n1_23) *% (t1_26) in 
-  let x2_28 :=
-    (nat_mod_zero ) -% ((n2_24) *% (t1_26)) in 
-  (x1_27, x2_28).
-  
-  QuickChick (forAll g_fp2 (fun n_22 : fp2 =>fp2inv n_22)).
+Definition fp2inv (n_20 : fp2) : fp2 :=
+  let '(n1_21, n2_22) :=
+    n_20 in 
+  let t0_23 :=
+    ((n1_21) *% (n1_21)) +% ((n2_22) *% (n2_22)) in 
+  let t1_24 :=
+    nat_mod_inv (t0_23) in 
+  let x1_25 :=
+    (n1_21) *% (t1_24) in 
+  let x2_26 :=
+    (nat_mod_zero ) -% ((n2_22) *% (t1_24)) in 
+  (x1_25, x2_26).
 
-Definition fp2conjugate (n_29 : fp2) : fp2 :=
-  let '(n1_30, n2_31) :=
-    n_29 in 
-  (n1_30, (nat_mod_zero ) -% (n2_31)).
-  
-  QuickChick (forAll g_fp2 (fun n_29 : fp2 =>fp2conjugate n_29)).
+Definition fp2conjugate (n_27 : fp2) : fp2 :=
+  let '(n1_28, n2_29) :=
+    n_27 in 
+  (n1_28, (nat_mod_zero ) -% (n2_29)).
 
-Definition fp6fromfp2 (n_32 : fp2) : fp6 :=
-  (n_32, fp2zero , fp2zero ).
-  
-  QuickChick (forAll g_fp2 (fun n_32 : fp2 =>fp6fromfp2 n_32)).
+Definition fp6fromfp2 (n_30 : fp2) : fp6 :=
+  (n_30, fp2zero , fp2zero ).
 
 Definition fp6zero  : fp6 :=
   fp6fromfp2 (fp2zero ).
-  
-  QuickChick (fp6zero).
 
-Definition fp6neg (n_33 : fp6) : fp6 :=
-  let '(n1_34, n2_35, n3_36) :=
-    n_33 in 
+Definition fp6neg (n_31 : fp6) : fp6 :=
+  let '(n1_32, n2_33, n3_34) :=
+    n_31 in 
   (
-    fp2sub (fp2zero ) (n1_34),
-    fp2sub (fp2zero ) (n2_35),
-    fp2sub (fp2zero ) (n3_36)
+    fp2sub (fp2zero ) (n1_32),
+    fp2sub (fp2zero ) (n2_33),
+    fp2sub (fp2zero ) (n3_34)
   ).
-  
-  QuickChick (forAll g_fp6 (fun n_33 : fp6 =>fp6neg n_33)).
 
-Definition fp6add (n_37 : fp6) (m_38 : fp6) : fp6 :=
-  let '(n1_39, n2_40, n3_41) :=
-    n_37 in 
-  let '(m1_42, m2_43, m3_44) :=
-    m_38 in 
-  (fp2add (n1_39) (m1_42), fp2add (n2_40) (m2_43), fp2add (n3_41) (m3_44)).
-  
-  QuickChick (
-    forAll g_fp6 (fun n_37 : fp6 =>forAll g_fp6 (fun m_38 : fp6 =>fp6add n_37) m_38)).
+Definition fp6add (n_35 : fp6) (m_36 : fp6) : fp6 :=
+  let '(n1_37, n2_38, n3_39) :=
+    n_35 in 
+  let '(m1_40, m2_41, m3_42) :=
+    m_36 in 
+  (fp2add (n1_37) (m1_40), fp2add (n2_38) (m2_41), fp2add (n3_39) (m3_42)).
 
-Definition fp6sub (n_45 : fp6) (m_46 : fp6) : fp6 :=
-  fp6add (n_45) (fp6neg (m_46)).
-  
-  QuickChick (
-    forAll g_fp6 (fun n_45 : fp6 =>forAll g_fp6 (fun m_46 : fp6 =>fp6sub n_45) m_46)).
+Definition fp6sub (n_43 : fp6) (m_44 : fp6) : fp6 :=
+  fp6add (n_43) (fp6neg (m_44)).
 
-Definition fp6mul (n_47 : fp6) (m_48 : fp6) : fp6 :=
-  let '(n1_49, n2_50, n3_51) :=
-    n_47 in 
-  let '(m1_52, m2_53, m3_54) :=
-    m_48 in 
-  let eps_55 :=
+Definition fp6mul (n_45 : fp6) (m_46 : fp6) : fp6 :=
+  let '(n1_47, n2_48, n3_49) :=
+    n_45 in 
+  let '(m1_50, m2_51, m3_52) :=
+    m_46 in 
+  let eps_53 :=
     (nat_mod_one , nat_mod_one ) in 
-  let t1_56 :=
-    fp2mul (n1_49) (m1_52) in 
-  let t2_57 :=
-    fp2mul (n2_50) (m2_53) in 
-  let t3_58 :=
-    fp2mul (n3_51) (m3_54) in 
-  let t4_59 :=
-    fp2mul (fp2add (n2_50) (n3_51)) (fp2add (m2_53) (m3_54)) in 
-  let t5_60 :=
-    fp2sub (fp2sub (t4_59) (t2_57)) (t3_58) in 
-  let x_61 :=
-    fp2add (fp2mul (t5_60) (eps_55)) (t1_56) in 
-  let t4_62 :=
-    fp2mul (fp2add (n1_49) (n2_50)) (fp2add (m1_52) (m2_53)) in 
-  let t5_63 :=
-    fp2sub (fp2sub (t4_62) (t1_56)) (t2_57) in 
-  let y_64 :=
-    fp2add (t5_63) (fp2mul (eps_55) (t3_58)) in 
-  let t4_65 :=
-    fp2mul (fp2add (n1_49) (n3_51)) (fp2add (m1_52) (m3_54)) in 
-  let t5_66 :=
-    fp2sub (fp2sub (t4_65) (t1_56)) (t3_58) in 
-  let z_67 :=
-    fp2add (t5_66) (t2_57) in 
-  (x_61, y_64, z_67).
-  
-  QuickChick (
-    forAll g_fp6 (fun n_47 : fp6 =>forAll g_fp6 (fun m_48 : fp6 =>fp6mul n_47) m_48)).
+  let t1_54 :=
+    fp2mul (n1_47) (m1_50) in 
+  let t2_55 :=
+    fp2mul (n2_48) (m2_51) in 
+  let t3_56 :=
+    fp2mul (n3_49) (m3_52) in 
+  let t4_57 :=
+    fp2mul (fp2add (n2_48) (n3_49)) (fp2add (m2_51) (m3_52)) in 
+  let t5_58 :=
+    fp2sub (fp2sub (t4_57) (t2_55)) (t3_56) in 
+  let x_59 :=
+    fp2add (fp2mul (t5_58) (eps_53)) (t1_54) in 
+  let t4_60 :=
+    fp2mul (fp2add (n1_47) (n2_48)) (fp2add (m1_50) (m2_51)) in 
+  let t5_61 :=
+    fp2sub (fp2sub (t4_60) (t1_54)) (t2_55) in 
+  let y_62 :=
+    fp2add (t5_61) (fp2mul (eps_53) (t3_56)) in 
+  let t4_63 :=
+    fp2mul (fp2add (n1_47) (n3_49)) (fp2add (m1_50) (m3_52)) in 
+  let t5_64 :=
+    fp2sub (fp2sub (t4_63) (t1_54)) (t3_56) in 
+  let z_65 :=
+    fp2add (t5_64) (t2_55) in 
+  (x_59, y_62, z_65).
 
-Definition fp6inv (n_68 : fp6) : fp6 :=
-  let '(n1_69, n2_70, n3_71) :=
-    n_68 in 
-  let eps_72 :=
+Definition fp6inv (n_66 : fp6) : fp6 :=
+  let '(n1_67, n2_68, n3_69) :=
+    n_66 in 
+  let eps_70 :=
     (nat_mod_one , nat_mod_one ) in 
-  let t1_73 :=
-    fp2mul (n1_69) (n1_69) in 
-  let t2_74 :=
-    fp2mul (n2_70) (n2_70) in 
-  let t3_75 :=
-    fp2mul (n3_71) (n3_71) in 
-  let t4_76 :=
-    fp2mul (n1_69) (n2_70) in 
-  let t5_77 :=
-    fp2mul (n1_69) (n3_71) in 
-  let t6_78 :=
-    fp2mul (n2_70) (n3_71) in 
-  let x0_79 :=
-    fp2sub (t1_73) (fp2mul (eps_72) (t6_78)) in 
-  let y0_80 :=
-    fp2sub (fp2mul (eps_72) (t3_75)) (t4_76) in 
-  let z0_81 :=
-    fp2sub (t2_74) (t5_77) in 
+  let t1_71 :=
+    fp2mul (n1_67) (n1_67) in 
+  let t2_72 :=
+    fp2mul (n2_68) (n2_68) in 
+  let t3_73 :=
+    fp2mul (n3_69) (n3_69) in 
+  let t4_74 :=
+    fp2mul (n1_67) (n2_68) in 
+  let t5_75 :=
+    fp2mul (n1_67) (n3_69) in 
+  let t6_76 :=
+    fp2mul (n2_68) (n3_69) in 
+  let x0_77 :=
+    fp2sub (t1_71) (fp2mul (eps_70) (t6_76)) in 
+  let y0_78 :=
+    fp2sub (fp2mul (eps_70) (t3_73)) (t4_74) in 
+  let z0_79 :=
+    fp2sub (t2_72) (t5_75) in 
+  let t0_80 :=
+    fp2mul (n1_67) (x0_77) in 
+  let t0_81 :=
+    fp2add (t0_80) (fp2mul (eps_70) (fp2mul (n3_69) (y0_78))) in 
   let t0_82 :=
-    fp2mul (n1_69) (x0_79) in 
+    fp2add (t0_81) (fp2mul (eps_70) (fp2mul (n2_68) (z0_79))) in 
   let t0_83 :=
-    fp2add (t0_82) (fp2mul (eps_72) (fp2mul (n3_71) (y0_80))) in 
-  let t0_84 :=
-    fp2add (t0_83) (fp2mul (eps_72) (fp2mul (n2_70) (z0_81))) in 
-  let t0_85 :=
-    fp2inv (t0_84) in 
-  let x_86 :=
-    fp2mul (x0_79) (t0_85) in 
-  let y_87 :=
-    fp2mul (y0_80) (t0_85) in 
-  let z_88 :=
-    fp2mul (z0_81) (t0_85) in 
-  (x_86, y_87, z_88).
-  
-  QuickChick (forAll g_fp6 (fun n_68 : fp6 =>fp6inv n_68)).
+    fp2inv (t0_82) in 
+  let x_84 :=
+    fp2mul (x0_77) (t0_83) in 
+  let y_85 :=
+    fp2mul (y0_78) (t0_83) in 
+  let z_86 :=
+    fp2mul (z0_79) (t0_83) in 
+  (x_84, y_85, z_86).
 
-Definition fp12fromfp6 (n_89 : fp6) : fp12 :=
-  (n_89, fp6zero ).
-  
-  QuickChick (forAll g_fp6 (fun n_89 : fp6 =>fp12fromfp6 n_89)).
+Definition fp12fromfp6 (n_87 : fp6) : fp12 :=
+  (n_87, fp6zero ).
 
-Definition fp12neg (n_90 : fp12) : fp12 :=
-  let '(n1_91, n2_92) :=
-    n_90 in 
-  (fp6sub (fp6zero ) (n1_91), fp6sub (fp6zero ) (n2_92)).
-  
-  QuickChick (forAll g_fp12 (fun n_90 : fp12 =>fp12neg n_90)).
+Definition fp12neg (n_88 : fp12) : fp12 :=
+  let '(n1_89, n2_90) :=
+    n_88 in 
+  (fp6sub (fp6zero ) (n1_89), fp6sub (fp6zero ) (n2_90)).
 
-Definition fp12add (n_93 : fp12) (m_94 : fp12) : fp12 :=
-  let '(n1_95, n2_96) :=
-    n_93 in 
-  let '(m1_97, m2_98) :=
-    m_94 in 
-  (fp6add (n1_95) (m1_97), fp6add (n2_96) (m2_98)).
-  
-  QuickChick (
-    forAll g_fp12 (fun n_93 : fp12 =>forAll g_fp12 (fun m_94 : fp12 =>fp12add n_93) m_94)).
+Definition fp12add (n_91 : fp12) (m_92 : fp12) : fp12 :=
+  let '(n1_93, n2_94) :=
+    n_91 in 
+  let '(m1_95, m2_96) :=
+    m_92 in 
+  (fp6add (n1_93) (m1_95), fp6add (n2_94) (m2_96)).
 
-Definition fp12sub (n_99 : fp12) (m_100 : fp12) : fp12 :=
-  fp12add (n_99) (fp12neg (m_100)).
-  
-  QuickChick (
-    forAll g_fp12 (fun n_99 : fp12 =>forAll g_fp12 (fun m_100 : fp12 =>fp12sub n_99) m_100)).
+Definition fp12sub (n_97 : fp12) (m_98 : fp12) : fp12 :=
+  fp12add (n_97) (fp12neg (m_98)).
 
-Definition fp12mul (n_101 : fp12) (m_102 : fp12) : fp12 :=
-  let '(n1_103, n2_104) :=
-    n_101 in 
-  let '(m1_105, m2_106) :=
-    m_102 in 
-  let gamma_107 :=
+Definition fp12mul (n_99 : fp12) (m_100 : fp12) : fp12 :=
+  let '(n1_101, n2_102) :=
+    n_99 in 
+  let '(m1_103, m2_104) :=
+    m_100 in 
+  let gamma_105 :=
     (fp2zero , fp2fromfp (nat_mod_one ), fp2zero ) in 
-  let t1_108 :=
-    fp6mul (n1_103) (m1_105) in 
-  let t2_109 :=
-    fp6mul (n2_104) (m2_106) in 
-  let x_110 :=
-    fp6add (t1_108) (fp6mul (t2_109) (gamma_107)) in 
-  let y_111 :=
-    fp6mul (fp6add (n1_103) (n2_104)) (fp6add (m1_105) (m2_106)) in 
-  let y_112 :=
-    fp6sub (fp6sub (y_111) (t1_108)) (t2_109) in 
-  (x_110, y_112).
-  
-  QuickChick (
-    forAll g_fp12 (fun n_101 : fp12 =>forAll g_fp12 (fun m_102 : fp12 =>fp12mul n_101) m_102)).
+  let t1_106 :=
+    fp6mul (n1_101) (m1_103) in 
+  let t2_107 :=
+    fp6mul (n2_102) (m2_104) in 
+  let x_108 :=
+    fp6add (t1_106) (fp6mul (t2_107) (gamma_105)) in 
+  let y_109 :=
+    fp6mul (fp6add (n1_101) (n2_102)) (fp6add (m1_103) (m2_104)) in 
+  let y_110 :=
+    fp6sub (fp6sub (y_109) (t1_106)) (t2_107) in 
+  (x_108, y_110).
 
-Definition fp12inv (n_113 : fp12) : fp12 :=
-  let '(n1_114, n2_115) :=
-    n_113 in 
-  let gamma_116 :=
+Definition fp12inv (n_111 : fp12) : fp12 :=
+  let '(n1_112, n2_113) :=
+    n_111 in 
+  let gamma_114 :=
     (fp2zero , fp2fromfp (nat_mod_one ), fp2zero ) in 
+  let t1_115 :=
+    fp6mul (n1_112) (n1_112) in 
+  let t2_116 :=
+    fp6mul (n2_113) (n2_113) in 
   let t1_117 :=
-    fp6mul (n1_114) (n1_114) in 
+    fp6sub (t1_115) (fp6mul (gamma_114) (t2_116)) in 
   let t2_118 :=
-    fp6mul (n2_115) (n2_115) in 
-  let t1_119 :=
-    fp6sub (t1_117) (fp6mul (gamma_116) (t2_118)) in 
-  let t2_120 :=
-    fp6inv (t1_119) in 
-  let x_121 :=
-    fp6mul (n1_114) (t2_120) in 
-  let y_122 :=
-    fp6neg (fp6mul (n2_115) (t2_120)) in 
-  (x_121, y_122).
-  
-  QuickChick (forAll g_fp12 (fun n_113 : fp12 =>fp12inv n_113)).
+    fp6inv (t1_117) in 
+  let x_119 :=
+    fp6mul (n1_112) (t2_118) in 
+  let y_120 :=
+    fp6neg (fp6mul (n2_113) (t2_118)) in 
+  (x_119, y_120).
 
-Definition fp12exp (n_123 : fp12) (k_124 : scalar) : fp12 :=
-  let l_125 :=
-    (usize 255) - (most_significant_bit (k_124) (usize 255)) in 
-  let c_126 :=
-    n_123 in 
-  let c_126 :=
-    foldi (l_125) (usize 255) (fun i_127 c_126 =>
-      let c_126 :=
-        fp12mul (c_126) (c_126) in 
-      let '(c_126) :=
-        if nat_mod_bit (k_124) (((usize 255) - (i_127)) - (usize 1)):bool then (
-          let c_126 :=
-            fp12mul (c_126) (n_123) in 
-          (c_126)
-        ) else ( (c_126)
+Definition fp12exp (n_121 : fp12) (k_122 : scalar) : fp12 :=
+  let c_123 :=
+    fp12fromfp6 (fp6fromfp2 (fp2fromfp (nat_mod_one ))) in 
+  let c_123 :=
+    foldi (usize 0) (usize 256) (fun i_124 c_123 =>
+      let c_123 :=
+        fp12mul (c_123) (c_123) in 
+      let '(c_123) :=
+        if nat_mod_bit (k_122) ((usize 255) - (i_124)):bool then (
+          let c_123 :=
+            fp12mul (c_123) (n_121) in 
+          (c_123)
+        ) else ( (c_123)
         ) in 
-      (c_126))
-    c_126 in 
-  c_126.
-  
-  QuickChick (
-    forAll g_fp12 (fun n_123 : fp12 =>forAll g_scalar (fun k_124 : scalar =>fp12exp n_123) k_124)).
+      (c_123))
+    c_123 in 
+  c_123.
 
-Definition fp12conjugate (n_128 : fp12) : fp12 :=
-  let '(n1_129, n2_130) :=
-    n_128 in 
-  (n1_129, fp6neg (n2_130)).
-  
-  QuickChick (forAll g_fp12 (fun n_128 : fp12 =>fp12conjugate n_128)).
+Definition fp12conjugate (n_125 : fp12) : fp12 :=
+  let '(n1_126, n2_127) :=
+    n_125 in 
+  (n1_126, fp6neg (n2_127)).
 
 Definition fp12zero  : fp12 :=
   fp12fromfp6 (fp6zero ).
-  
-  QuickChick (fp12zero).
 
-Definition g1add_a (p_131 : g1) (q_132 : g1) : g1 :=
-  let '(x1_133, y1_134, _) :=
-    p_131 in 
-  let '(x2_135, y2_136, _) :=
-    q_132 in 
-  let x_diff_137 :=
-    (x2_135) -% (x1_133) in 
-  let y_diff_138 :=
-    (y2_136) -% (y1_134) in 
-  let xovery_139 :=
-    (y_diff_138) *% (nat_mod_inv (x_diff_137)) in 
-  let x3_140 :=
-    ((nat_mod_exp (xovery_139) (repr 2)) -% (x1_133)) -% (x2_135) in 
-  let y3_141 :=
-    ((xovery_139) *% ((x1_133) -% (x3_140))) -% (y1_134) in 
-  (x3_140, y3_141, false).
-  
-  QuickChick (
-    forAll g_g1 (fun p_131 : g1 =>forAll g_g1 (fun q_132 : g1 =>g1add_a p_131) q_132)).
+Definition g1add_a (p_128 : g1) (q_129 : g1) : g1 :=
+  let '(x1_130, y1_131, _) :=
+    p_128 in 
+  let '(x2_132, y2_133, _) :=
+    q_129 in 
+  let x_diff_134 :=
+    (x2_132) -% (x1_130) in 
+  let y_diff_135 :=
+    (y2_133) -% (y1_131) in 
+  let xovery_136 :=
+    (y_diff_135) *% (nat_mod_inv (x_diff_134)) in 
+  let x3_137 :=
+    ((nat_mod_exp (xovery_136) (repr 2)) -% (x1_130)) -% (x2_132) in 
+  let y3_138 :=
+    ((xovery_136) *% ((x1_130) -% (x3_137))) -% (y1_131) in 
+  (x3_137, y3_138, false).
 
-Definition g1double_a (p_142 : g1) : g1 :=
-  let '(x1_143, y1_144, _) :=
-    p_142 in 
-  let x12_145 :=
-    nat_mod_exp (x1_143) (repr 2) in 
-  let xovery_146 :=
+Definition g1double_a (p_139 : g1) : g1 :=
+  let '(x1_140, y1_141, _) :=
+    p_139 in 
+  let x12_142 :=
+    nat_mod_exp (x1_140) (repr 2) in 
+  let xovery_143 :=
     (
       (
         nat_mod_from_literal (
           0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab) (
-          repr 3)) *% (x12_145)) *% (
-      nat_mod_inv ((nat_mod_two ) *% (y1_144))) in 
-  let x3_147 :=
-    (nat_mod_exp (xovery_146) (repr 2)) -% ((nat_mod_two ) *% (x1_143)) in 
-  let y3_148 :=
-    ((xovery_146) *% ((x1_143) -% (x3_147))) -% (y1_144) in 
-  (x3_147, y3_148, false).
-  
-  QuickChick (forAll g_g1 (fun p_142 : g1 =>g1double_a p_142)).
+          repr 3)) *% (x12_142)) *% (
+      nat_mod_inv ((nat_mod_two ) *% (y1_141))) in 
+  let x3_144 :=
+    (nat_mod_exp (xovery_143) (repr 2)) -% ((nat_mod_two ) *% (x1_140)) in 
+  let y3_145 :=
+    ((xovery_143) *% ((x1_140) -% (x3_144))) -% (y1_141) in 
+  (x3_144, y3_145, false).
 
-Definition g1double (p_149 : g1) : g1 :=
-  let '(x1_150, y1_151, inf1_152) :=
-    p_149 in 
-  if (((y1_151) !=.? (nat_mod_zero )) && (negb (inf1_152))):bool then (
-    g1double_a (p_149)) else ((nat_mod_zero , nat_mod_zero , true)).
-  
-  QuickChick (forAll g_g1 (fun p_149 : g1 =>g1double p_149)).
+Definition g1double (p_146 : g1) : g1 :=
+  let '(x1_147, y1_148, inf1_149) :=
+    p_146 in 
+  if (((y1_148) !=.? (nat_mod_zero )) && (negb (inf1_149))):bool then (
+    g1double_a (p_146)) else ((nat_mod_zero , nat_mod_zero , true)).
 
-Definition g1add (p_153 : g1) (q_154 : g1) : g1 :=
-  let '(x1_155, y1_156, inf1_157) :=
-    p_153 in 
-  let '(x2_158, y2_159, inf2_160) :=
-    q_154 in 
-  if (inf1_157):bool then (q_154) else (
-    if (inf2_160):bool then (p_153) else (
-      if ((p_153) =.? (q_154)):bool then (g1double (p_153)) else (
+Definition g1add (p_150 : g1) (q_151 : g1) : g1 :=
+  let '(x1_152, y1_153, inf1_154) :=
+    p_150 in 
+  let '(x2_155, y2_156, inf2_157) :=
+    q_151 in 
+  if (inf1_154):bool then (q_151) else (
+    if (inf2_157):bool then (p_150) else (
+      if ((p_150) =.? (q_151)):bool then (g1double (p_150)) else (
         if (
           negb (
-            ((x1_155) =.? (x2_158)) && (
-              (y1_156) =.? ((nat_mod_zero ) -% (y2_159))))):bool then (
-          g1add_a (p_153) (q_154)) else (
+            ((x1_152) =.? (x2_155)) && (
+              (y1_153) =.? ((nat_mod_zero ) -% (y2_156))))):bool then (
+          g1add_a (p_150) (q_151)) else (
           (nat_mod_zero , nat_mod_zero , true))))).
-  
-  QuickChick (
-    forAll g_g1 (fun p_153 : g1 =>forAll g_g1 (fun q_154 : g1 =>g1add p_153) q_154)).
 
-Definition g1mul (m_161 : scalar) (p_162 : g1) : g1 :=
-  let n_163 :=
-    usize 255 in 
-  let k_164 :=
-    (n_163) - (most_significant_bit (m_161) (n_163)) in 
-  let t_165 :=
-    p_162 in 
-  let t_165 :=
-    foldi (k_164) (n_163) (fun i_166 t_165 =>
-      let t_165 :=
-        g1double (t_165) in 
-      let '(t_165) :=
-        if nat_mod_bit (m_161) (((n_163) - (i_166)) - (usize 1)):bool then (
-          let t_165 :=
-            g1add (t_165) (p_162) in 
-          (t_165)
-        ) else ( (t_165)
+Definition g1mul (m_158 : scalar) (p_159 : g1) : g1 :=
+  let t_160 :=
+    (nat_mod_zero , nat_mod_zero , true) in 
+  let t_160 :=
+    foldi (usize 0) (usize 256) (fun i_161 t_160 =>
+      let t_160 :=
+        g1double (t_160) in 
+      let '(t_160) :=
+        if nat_mod_bit (m_158) ((usize 255) - (i_161)):bool then (
+          let t_160 :=
+            g1add (t_160) (p_159) in 
+          (t_160)
+        ) else ( (t_160)
         ) in 
-      (t_165))
-    t_165 in 
-  t_165.
-  
-  QuickChick (
-    forAll g_scalar (fun m_161 : scalar =>forAll g_g1 (fun p_162 : g1 =>g1mul m_161) p_162)).
+      (t_160))
+    t_160 in 
+  t_160.
 
-Definition g1neg (p_167 : g1) : g1 :=
-  let '(x_168, y_169, inf_170) :=
-    p_167 in 
-  (x_168, (nat_mod_zero ) -% (y_169), inf_170).
-  
-  QuickChick (forAll g_g1 (fun p_167 : g1 =>g1neg p_167)).
+Definition g1neg (p_162 : g1) : g1 :=
+  let '(x_163, y_164, inf_165) :=
+    p_162 in 
+  (x_163, (nat_mod_zero ) -% (y_164), inf_165).
 
-Definition g2add_a (p_171 : g2) (q_172 : g2) : g2 :=
-  let '(x1_173, y1_174, _) :=
-    p_171 in 
-  let '(x2_175, y2_176, _) :=
-    q_172 in 
-  let x_diff_177 :=
-    fp2sub (x2_175) (x1_173) in 
-  let y_diff_178 :=
-    fp2sub (y2_176) (y1_174) in 
-  let xovery_179 :=
-    fp2mul (y_diff_178) (fp2inv (x_diff_177)) in 
-  let t1_180 :=
-    fp2mul (xovery_179) (xovery_179) in 
-  let t2_181 :=
-    fp2sub (t1_180) (x1_173) in 
-  let x3_182 :=
-    fp2sub (t2_181) (x2_175) in 
-  let t1_183 :=
-    fp2sub (x1_173) (x3_182) in 
-  let t2_184 :=
-    fp2mul (xovery_179) (t1_183) in 
-  let y3_185 :=
-    fp2sub (t2_184) (y1_174) in 
-  (x3_182, y3_185, false).
-  
-  QuickChick (
-    forAll g_g2 (fun p_171 : g2 =>forAll g_g2 (fun q_172 : g2 =>g2add_a p_171) q_172)).
+Definition g2add_a (p_166 : g2) (q_167 : g2) : g2 :=
+  let '(x1_168, y1_169, _) :=
+    p_166 in 
+  let '(x2_170, y2_171, _) :=
+    q_167 in 
+  let x_diff_172 :=
+    fp2sub (x2_170) (x1_168) in 
+  let y_diff_173 :=
+    fp2sub (y2_171) (y1_169) in 
+  let xovery_174 :=
+    fp2mul (y_diff_173) (fp2inv (x_diff_172)) in 
+  let t1_175 :=
+    fp2mul (xovery_174) (xovery_174) in 
+  let t2_176 :=
+    fp2sub (t1_175) (x1_168) in 
+  let x3_177 :=
+    fp2sub (t2_176) (x2_170) in 
+  let t1_178 :=
+    fp2sub (x1_168) (x3_177) in 
+  let t2_179 :=
+    fp2mul (xovery_174) (t1_178) in 
+  let y3_180 :=
+    fp2sub (t2_179) (y1_169) in 
+  (x3_177, y3_180, false).
 
-Definition g2double_a (p_186 : g2) : g2 :=
-  let '(x1_187, y1_188, _) :=
-    p_186 in 
-  let x12_189 :=
-    fp2mul (x1_187) (x1_187) in 
-  let t1_190 :=
+Definition g2double_a (p_181 : g2) : g2 :=
+  let '(x1_182, y1_183, _) :=
+    p_181 in 
+  let x12_184 :=
+    fp2mul (x1_182) (x1_182) in 
+  let t1_185 :=
     fp2mul (
       fp2fromfp (
         nat_mod_from_literal (
           0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab) (
-          repr 3))) (x12_189) in 
-  let t2_191 :=
-    fp2inv (fp2mul (fp2fromfp (nat_mod_two )) (y1_188)) in 
-  let xovery_192 :=
-    fp2mul (t1_190) (t2_191) in 
-  let t1_193 :=
-    fp2mul (xovery_192) (xovery_192) in 
-  let t2_194 :=
-    fp2mul (fp2fromfp (nat_mod_two )) (x1_187) in 
-  let x3_195 :=
-    fp2sub (t1_193) (t2_194) in 
-  let t1_196 :=
-    fp2sub (x1_187) (x3_195) in 
-  let t2_197 :=
-    fp2mul (xovery_192) (t1_196) in 
-  let y3_198 :=
-    fp2sub (t2_197) (y1_188) in 
-  (x3_195, y3_198, false).
-  
-  QuickChick (forAll g_g2 (fun p_186 : g2 =>g2double_a p_186)).
+          repr 3))) (x12_184) in 
+  let t2_186 :=
+    fp2inv (fp2mul (fp2fromfp (nat_mod_two )) (y1_183)) in 
+  let xovery_187 :=
+    fp2mul (t1_185) (t2_186) in 
+  let t1_188 :=
+    fp2mul (xovery_187) (xovery_187) in 
+  let t2_189 :=
+    fp2mul (fp2fromfp (nat_mod_two )) (x1_182) in 
+  let x3_190 :=
+    fp2sub (t1_188) (t2_189) in 
+  let t1_191 :=
+    fp2sub (x1_182) (x3_190) in 
+  let t2_192 :=
+    fp2mul (xovery_187) (t1_191) in 
+  let y3_193 :=
+    fp2sub (t2_192) (y1_183) in 
+  (x3_190, y3_193, false).
 
-Definition g2double (p_199 : g2) : g2 :=
+Definition g2double (p_194 : g2) : g2 :=
+  let '(x1_195, y1_196, inf1_197) :=
+    p_194 in 
+  if (((y1_196) !=.? (fp2zero )) && (negb (inf1_197))):bool then (
+    g2double_a (p_194)) else ((fp2zero , fp2zero , true)).
+
+Definition g2add (p_198 : g2) (q_199 : g2) : g2 :=
   let '(x1_200, y1_201, inf1_202) :=
-    p_199 in 
-  if (((y1_201) !=.? (fp2zero )) && (negb (inf1_202))):bool then (
-    g2double_a (p_199)) else ((fp2zero , fp2zero , true)).
-  
-  QuickChick (forAll g_g2 (fun p_199 : g2 =>g2double p_199)).
-
-Definition g2add (p_203 : g2) (q_204 : g2) : g2 :=
-  let '(x1_205, y1_206, inf1_207) :=
-    p_203 in 
-  let '(x2_208, y2_209, inf2_210) :=
-    q_204 in 
-  if (inf1_207):bool then (q_204) else (
-    if (inf2_210):bool then (p_203) else (
-      if ((p_203) =.? (q_204)):bool then (g2double (p_203)) else (
+    p_198 in 
+  let '(x2_203, y2_204, inf2_205) :=
+    q_199 in 
+  if (inf1_202):bool then (q_199) else (
+    if (inf2_205):bool then (p_198) else (
+      if ((p_198) =.? (q_199)):bool then (g2double (p_198)) else (
         if (
           negb (
-            ((x1_205) =.? (x2_208)) && (
-              (y1_206) =.? (fp2neg (y2_209))))):bool then (
-          g2add_a (p_203) (q_204)) else ((fp2zero , fp2zero , true))))).
-  
-  QuickChick (
-    forAll g_g2 (fun p_203 : g2 =>forAll g_g2 (fun q_204 : g2 =>g2add p_203) q_204)).
+            ((x1_200) =.? (x2_203)) && (
+              (y1_201) =.? (fp2neg (y2_204))))):bool then (
+          g2add_a (p_198) (q_199)) else ((fp2zero , fp2zero , true))))).
 
-Definition g2mul (m_211 : scalar) (p_212 : g2) : g2 :=
-  let n_213 :=
-    usize 255 in 
-  let k_214 :=
-    (n_213) - (most_significant_bit (m_211) (n_213)) in 
-  let t_215 :=
-    p_212 in 
-  let t_215 :=
-    foldi (k_214) (n_213) (fun i_216 t_215 =>
-      let t_215 :=
-        g2double (t_215) in 
-      let '(t_215) :=
-        if nat_mod_bit (m_211) (((n_213) - (i_216)) - (usize 1)):bool then (
-          let t_215 :=
-            g2add (t_215) (p_212) in 
-          (t_215)
-        ) else ( (t_215)
+Definition g2mul (m_206 : scalar) (p_207 : g2) : g2 :=
+  let t_208 :=
+    (fp2zero , fp2zero , true) in 
+  let t_208 :=
+    foldi (usize 0) (usize 256) (fun i_209 t_208 =>
+      let t_208 :=
+        g2double (t_208) in 
+      let '(t_208) :=
+        if nat_mod_bit (m_206) ((usize 255) - (i_209)):bool then (
+          let t_208 :=
+            g2add (t_208) (p_207) in 
+          (t_208)
+        ) else ( (t_208)
         ) in 
-      (t_215))
-    t_215 in 
-  t_215.
-  
-  QuickChick (
-    forAll g_scalar (fun m_211 : scalar =>forAll g_g2 (fun p_212 : g2 =>g2mul m_211) p_212)).
+      (t_208))
+    t_208 in 
+  t_208.
 
-Definition g2neg (p_217 : g2) : g2 :=
-  let '(x_218, y_219, inf_220) :=
-    p_217 in 
-  (x_218, fp2neg (y_219), inf_220).
-  
-  QuickChick (forAll g_g2 (fun p_217 : g2 =>g2neg p_217)).
+Definition g2neg (p_210 : g2) : g2 :=
+  let '(x_211, y_212, inf_213) :=
+    p_210 in 
+  (x_211, fp2neg (y_212), inf_213).
 
-Definition twist (p_221 : g1) : (fp12 × fp12) :=
-  let '(p0_222, p1_223, _) :=
-    p_221 in 
-  let x_224 :=
-    ((fp2zero , fp2fromfp (p0_222), fp2zero ), fp6zero ) in 
-  let y_225 :=
-    (fp6zero , (fp2zero , fp2fromfp (p1_223), fp2zero )) in 
-  (x_224, y_225).
-  
-  QuickChick (forAll g_g1 (fun p_221 : g1 =>twist p_221)).
+Definition twist (p_214 : g1) : (fp12 × fp12) :=
+  let '(p0_215, p1_216, _) :=
+    p_214 in 
+  let x_217 :=
+    ((fp2zero , fp2fromfp (p0_215), fp2zero ), fp6zero ) in 
+  let y_218 :=
+    (fp6zero , (fp2zero , fp2fromfp (p1_216), fp2zero )) in 
+  (x_217, y_218).
 
-Definition line_double_p (r_226 : g2) (p_227 : g1) : fp12 :=
-  let '(r0_228, r1_229, _) :=
-    r_226 in 
-  let a_230 :=
+Definition line_double_p (r_219 : g2) (p_220 : g1) : fp12 :=
+  let '(r0_221, r1_222, _) :=
+    r_219 in 
+  let a_223 :=
     fp2mul (
       fp2fromfp (
         nat_mod_from_literal (
           0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab) (
-          repr 3))) (fp2mul (r0_228) (r0_228)) in 
-  let a_231 :=
-    fp2mul (a_230) (fp2inv (fp2mul (fp2fromfp (nat_mod_two )) (r1_229))) in 
-  let b_232 :=
-    fp2sub (r1_229) (fp2mul (a_231) (r0_228)) in 
-  let a_233 :=
-    fp12fromfp6 (fp6fromfp2 (a_231)) in 
-  let b_234 :=
-    fp12fromfp6 (fp6fromfp2 (b_232)) in 
-  let '(x_235, y_236) :=
-    twist (p_227) in 
-  fp12neg (fp12sub (fp12sub (y_236) (fp12mul (a_233) (x_235))) (b_234)).
-  
-  QuickChick (
-    forAll g_g2 (fun r_226 : g2 =>forAll g_g1 (fun p_227 : g1 =>line_double_p r_226) p_227)).
+          repr 3))) (fp2mul (r0_221) (r0_221)) in 
+  let a_224 :=
+    fp2mul (a_223) (fp2inv (fp2mul (fp2fromfp (nat_mod_two )) (r1_222))) in 
+  let b_225 :=
+    fp2sub (r1_222) (fp2mul (a_224) (r0_221)) in 
+  let a_226 :=
+    fp12fromfp6 (fp6fromfp2 (a_224)) in 
+  let b_227 :=
+    fp12fromfp6 (fp6fromfp2 (b_225)) in 
+  let '(x_228, y_229) :=
+    twist (p_220) in 
+  fp12neg (fp12sub (fp12sub (y_229) (fp12mul (a_226) (x_228))) (b_227)).
 
-Definition line_add_p (r_237 : g2) (q_238 : g2) (p_239 : g1) : fp12 :=
-  let '(r0_240, r1_241, _) :=
-    r_237 in 
-  let '(q0_242, q1_243, _) :=
-    q_238 in 
-  let a_244 :=
-    fp2mul (fp2sub (q1_243) (r1_241)) (fp2inv (fp2sub (q0_242) (r0_240))) in 
-  let b_245 :=
-    fp2sub (r1_241) (fp2mul (a_244) (r0_240)) in 
-  let a_246 :=
-    fp12fromfp6 (fp6fromfp2 (a_244)) in 
-  let b_247 :=
-    fp12fromfp6 (fp6fromfp2 (b_245)) in 
-  let '(x_248, y_249) :=
-    twist (p_239) in 
-  fp12neg (fp12sub (fp12sub (y_249) (fp12mul (a_246) (x_248))) (b_247)).
-  
-  QuickChick (
-    forAll g_g2 (fun r_237 : g2 =>forAll g_g2 (fun q_238 : g2 =>forAll g_g1 (fun p_239 : g1 =>line_add_p r_237) q_238) p_239)).
+Definition line_add_p (r_230 : g2) (q_231 : g2) (p_232 : g1) : fp12 :=
+  let '(r0_233, r1_234, _) :=
+    r_230 in 
+  let '(q0_235, q1_236, _) :=
+    q_231 in 
+  let a_237 :=
+    fp2mul (fp2sub (q1_236) (r1_234)) (fp2inv (fp2sub (q0_235) (r0_233))) in 
+  let b_238 :=
+    fp2sub (r1_234) (fp2mul (a_237) (r0_233)) in 
+  let a_239 :=
+    fp12fromfp6 (fp6fromfp2 (a_237)) in 
+  let b_240 :=
+    fp12fromfp6 (fp6fromfp2 (b_238)) in 
+  let '(x_241, y_242) :=
+    twist (p_232) in 
+  fp12neg (fp12sub (fp12sub (y_242) (fp12mul (a_239) (x_241))) (b_240)).
 
-Definition frobenius (f_250 : fp12) : fp12 :=
-  let '((g0_251, g1_252, g2_253), (h0_254, h1_255, h2_256)) :=
-    f_250 in 
-  let t1_257 :=
-    fp2conjugate (g0_251) in 
-  let t2_258 :=
-    fp2conjugate (h0_254) in 
-  let t3_259 :=
-    fp2conjugate (g1_252) in 
-  let t4_260 :=
-    fp2conjugate (h1_255) in 
-  let t5_261 :=
-    fp2conjugate (g2_253) in 
-  let t6_262 :=
-    fp2conjugate (h2_256) in 
-  let c1_263 :=
+Definition frobenius (f_243 : fp12) : fp12 :=
+  let '((g0_244, g1_245, g2_246), (h0_247, h1_248, h2_249)) :=
+    f_243 in 
+  let t1_250 :=
+    fp2conjugate (g0_244) in 
+  let t2_251 :=
+    fp2conjugate (h0_247) in 
+  let t3_252 :=
+    fp2conjugate (g1_245) in 
+  let t4_253 :=
+    fp2conjugate (h1_248) in 
+  let t5_254 :=
+    fp2conjugate (g2_246) in 
+  let t6_255 :=
+    fp2conjugate (h2_249) in 
+  let c1_256 :=
     array_from_list uint64 (
       let l :=
         [
@@ -684,11 +572,11 @@ Definition frobenius (f_250 : fp12) : fp12 :=
           secret (repr 13993175198059990303);
           secret (repr 1802798568193066599)
         ] in  l) in 
-  let c1_264 :=
-    array_to_le_bytes (c1_263) in 
-  let c1_265 :=
-    nat_mod_from_byte_seq_le (c1_264) in 
-  let c2_266 :=
+  let c1_257 :=
+    array_to_le_bytes (c1_256) in 
+  let c1_258 :=
+    nat_mod_from_byte_seq_le (c1_257) in 
+  let c2_259 :=
     array_from_list uint64 (
       let l :=
         [
@@ -699,189 +587,210 @@ Definition frobenius (f_250 : fp12) : fp12 :=
           secret (repr 9865672654120263608);
           secret (repr 71000049454473266)
         ] in  l) in 
-  let c2_267 :=
-    array_to_le_bytes (c2_266) in 
-  let c2_268 :=
-    nat_mod_from_byte_seq_le (c2_267) in 
-  let gamma11_269 :=
-    (c1_265, c2_268) in 
-  let gamma12_270 :=
-    fp2mul (gamma11_269) (gamma11_269) in 
-  let gamma13_271 :=
-    fp2mul (gamma12_270) (gamma11_269) in 
-  let gamma14_272 :=
-    fp2mul (gamma13_271) (gamma11_269) in 
-  let gamma15_273 :=
-    fp2mul (gamma14_272) (gamma11_269) in 
-  let t2_274 :=
-    fp2mul (t2_258) (gamma11_269) in 
-  let t3_275 :=
-    fp2mul (t3_259) (gamma12_270) in 
-  let t4_276 :=
-    fp2mul (t4_260) (gamma13_271) in 
-  let t5_277 :=
-    fp2mul (t5_261) (gamma14_272) in 
-  let t6_278 :=
-    fp2mul (t6_262) (gamma15_273) in 
-  ((t1_257, t3_275, t5_277), (t2_274, t4_276, t6_278)).
-  
-  QuickChick (forAll g_fp12 (fun f_250 : fp12 =>frobenius f_250)).
+  let c2_260 :=
+    array_to_le_bytes (c2_259) in 
+  let c2_261 :=
+    nat_mod_from_byte_seq_le (c2_260) in 
+  let gamma11_262 :=
+    (c1_258, c2_261) in 
+  let gamma12_263 :=
+    fp2mul (gamma11_262) (gamma11_262) in 
+  let gamma13_264 :=
+    fp2mul (gamma12_263) (gamma11_262) in 
+  let gamma14_265 :=
+    fp2mul (gamma13_264) (gamma11_262) in 
+  let gamma15_266 :=
+    fp2mul (gamma14_265) (gamma11_262) in 
+  let t2_267 :=
+    fp2mul (t2_251) (gamma11_262) in 
+  let t3_268 :=
+    fp2mul (t3_252) (gamma12_263) in 
+  let t4_269 :=
+    fp2mul (t4_253) (gamma13_264) in 
+  let t5_270 :=
+    fp2mul (t5_254) (gamma14_265) in 
+  let t6_271 :=
+    fp2mul (t6_255) (gamma15_266) in 
+  ((t1_250, t3_268, t5_270), (t2_267, t4_269, t6_271)).
 
-Definition final_exponentiation (f_279 : fp12) : fp12 :=
-  let fp6_280 :=
-    fp12conjugate (f_279) in 
-  let finv_281 :=
-    fp12inv (f_279) in 
-  let fp6_1_282 :=
-    fp12mul (fp6_280) (finv_281) in 
-  let fp8_283 :=
-    frobenius (frobenius (fp6_1_282)) in 
-  let f_284 :=
-    fp12mul (fp8_283) (fp6_1_282) in 
-  let u_285 :=
+Definition final_exponentiation (f_272 : fp12) : fp12 :=
+  let fp6_273 :=
+    fp12conjugate (f_272) in 
+  let finv_274 :=
+    fp12inv (f_272) in 
+  let fp6_1_275 :=
+    fp12mul (fp6_273) (finv_274) in 
+  let fp8_276 :=
+    frobenius (frobenius (fp6_1_275)) in 
+  let f_277 :=
+    fp12mul (fp8_276) (fp6_1_275) in 
+  let u_278 :=
     nat_mod_from_literal (
       0x8000000000000000000000000000000000000000000000000000000000000000) (
       repr 15132376222941642752) in 
-  let t0_286 :=
-    fp12mul (f_284) (f_284) in 
+  let t0_279 :=
+    fp12mul (f_277) (f_277) in 
+  let t1_280 :=
+    fp12exp (t0_279) (u_278) in 
+  let t1_281 :=
+    fp12conjugate (t1_280) in 
+  let t2_282 :=
+    fp12exp (t1_281) ((u_278) /% (nat_mod_two )) in 
+  let t2_283 :=
+    fp12conjugate (t2_282) in 
+  let t3_284 :=
+    fp12conjugate (f_277) in 
+  let t1_285 :=
+    fp12mul (t3_284) (t1_281) in 
+  let t1_286 :=
+    fp12conjugate (t1_285) in 
   let t1_287 :=
-    fp12exp (t0_286) (u_285) in 
-  let t1_288 :=
-    fp12conjugate (t1_287) in 
+    fp12mul (t1_286) (t2_283) in 
+  let t2_288 :=
+    fp12exp (t1_287) (u_278) in 
   let t2_289 :=
-    fp12exp (t1_288) ((u_285) /% (nat_mod_two )) in 
-  let t2_290 :=
-    fp12conjugate (t2_289) in 
+    fp12conjugate (t2_288) in 
+  let t3_290 :=
+    fp12exp (t2_289) (u_278) in 
   let t3_291 :=
-    fp12conjugate (f_284) in 
+    fp12conjugate (t3_290) in 
   let t1_292 :=
-    fp12mul (t3_291) (t1_288) in 
-  let t1_293 :=
-    fp12conjugate (t1_292) in 
+    fp12conjugate (t1_287) in 
+  let t3_293 :=
+    fp12mul (t1_292) (t3_291) in 
   let t1_294 :=
-    fp12mul (t1_293) (t2_290) in 
-  let t2_295 :=
-    fp12exp (t1_294) (u_285) in 
+    fp12conjugate (t1_292) in 
+  let t1_295 :=
+    frobenius (frobenius (frobenius (t1_294))) in 
   let t2_296 :=
-    fp12conjugate (t2_295) in 
-  let t3_297 :=
-    fp12exp (t2_296) (u_285) in 
-  let t3_298 :=
-    fp12conjugate (t3_297) in 
-  let t1_299 :=
-    fp12conjugate (t1_294) in 
-  let t3_300 :=
-    fp12mul (t1_299) (t3_298) in 
-  let t1_301 :=
-    fp12conjugate (t1_299) in 
+    frobenius (frobenius (t2_289)) in 
+  let t1_297 :=
+    fp12mul (t1_295) (t2_296) in 
+  let t2_298 :=
+    fp12exp (t3_293) (u_278) in 
+  let t2_299 :=
+    fp12conjugate (t2_298) in 
+  let t2_300 :=
+    fp12mul (t2_299) (t0_279) in 
+  let t2_301 :=
+    fp12mul (t2_300) (f_277) in 
   let t1_302 :=
-    frobenius (frobenius (frobenius (t1_301))) in 
+    fp12mul (t1_297) (t2_301) in 
   let t2_303 :=
-    frobenius (frobenius (t2_296)) in 
+    frobenius (t3_293) in 
   let t1_304 :=
     fp12mul (t1_302) (t2_303) in 
-  let t2_305 :=
-    fp12exp (t3_300) (u_285) in 
-  let t2_306 :=
-    fp12conjugate (t2_305) in 
-  let t2_307 :=
-    fp12mul (t2_306) (t0_286) in 
-  let t2_308 :=
-    fp12mul (t2_307) (f_284) in 
-  let t1_309 :=
-    fp12mul (t1_304) (t2_308) in 
-  let t2_310 :=
-    frobenius (t3_300) in 
-  let t1_311 :=
-    fp12mul (t1_309) (t2_310) in 
-  t1_311.
-  
-  QuickChick (forAll g_fp12 (fun f_279 : fp12 =>final_exponentiation f_279)).
+  t1_304.
 
-Definition pairing (p_312 : g1) (q_313 : g2) : fp12 :=
-  let t_314 :=
+Definition pairing (p_305 : g1) (q_306 : g2) : fp12 :=
+  let t_307 :=
     nat_mod_from_literal (
       0x8000000000000000000000000000000000000000000000000000000000000000) (
       repr 15132376222941642752) in 
-  let r_315 :=
-    q_313 in 
-  let f_316 :=
+  let r_308 :=
+    q_306 in 
+  let f_309 :=
     fp12fromfp6 (fp6fromfp2 (fp2fromfp (nat_mod_one ))) in 
-  let '(r_315, f_316) :=
-    foldi (usize 1) (usize 64) (fun i_317 '(r_315, f_316) =>
-      let lrr_318 :=
-        line_double_p (r_315) (p_312) in 
-      let r_315 :=
-        g2double (r_315) in 
-      let f_316 :=
-        fp12mul (fp12mul (f_316) (f_316)) (lrr_318) in 
-      let '(r_315, f_316) :=
-        if nat_mod_bit (t_314) (((usize 64) - (i_317)) - (usize 1)):bool then (
-          let lrq_319 :=
-            line_add_p (r_315) (q_313) (p_312) in 
-          let r_315 :=
-            g2add (r_315) (q_313) in 
-          let f_316 :=
-            fp12mul (f_316) (lrq_319) in 
-          (r_315, f_316)
-        ) else ( (r_315, f_316)
+  let '(r_308, f_309) :=
+    foldi (usize 1) (usize 64) (fun i_310 '(r_308, f_309) =>
+      let lrr_311 :=
+        line_double_p (r_308) (p_305) in 
+      let r_308 :=
+        g2double (r_308) in 
+      let f_309 :=
+        fp12mul (fp12mul (f_309) (f_309)) (lrr_311) in 
+      let '(r_308, f_309) :=
+        if nat_mod_bit (t_307) (((usize 64) - (i_310)) - (usize 1)):bool then (
+          let lrq_312 :=
+            line_add_p (r_308) (q_306) (p_305) in 
+          let r_308 :=
+            g2add (r_308) (q_306) in 
+          let f_309 :=
+            fp12mul (f_309) (lrq_312) in 
+          (r_308, f_309)
+        ) else ( (r_308, f_309)
         ) in 
-      (r_315, f_316))
-    (r_315, f_316) in 
-  final_exponentiation (fp12conjugate (f_316)).
-  
-  QuickChick (
-    forAll g_g1 (fun p_312 : g1 =>forAll g_g2 (fun q_313 : g2 =>pairing p_312) q_313)).
+      (r_308, f_309))
+    (r_308, f_309) in 
+  final_exponentiation (fp12conjugate (f_309)).
 
-Definition test_fp2_prop_add_neg (a_320 : fp2) : bool :=
-  let b_321 :=
-    fp2neg (a_320) in 
-  (fp2fromfp (nat_mod_zero )) =.? (fp2add (a_320) (b_321)).
-  
-  QuickChick (forAll g_fp2 (fun a_320 : fp2 =>test_fp2_prop_add_neg a_320)).
+Definition test_fp2_prop_add_neg (a_313 : fp2) : bool :=
+  let b_314 :=
+    fp2neg (a_313) in 
+  (fp2fromfp (nat_mod_zero )) =.? (fp2add (a_313) (b_314)).
+QuickChick (forAll g_fp2 (fun a_313 : fp2 =>test_fp2_prop_add_neg a_313)).
 
-Definition test_fp2_prop_mul_inv (a_322 : fp2) : bool :=
-  let b_323 :=
-    fp2inv (a_322) in 
-  (fp2fromfp (nat_mod_one )) =.? (fp2mul (a_322) (b_323)).
-  
-  QuickChick (forAll g_fp2 (fun a_322 : fp2 =>test_fp2_prop_mul_inv a_322)).
+
+Theorem test_fp2_prop_add_neg_correct : forall a_313 : fp2 ,test_fp2_prop_add_neg a_313 = true.
+Proof. Admitted.
+
+
+Definition test_fp2_prop_mul_inv (a_315 : fp2) : bool :=
+  let b_316 :=
+    fp2inv (a_315) in 
+  (fp2fromfp (nat_mod_one )) =.? (fp2mul (a_315) (b_316)).
+QuickChick (forAll g_fp2 (fun a_315 : fp2 =>test_fp2_prop_mul_inv a_315)).
+
+
+Theorem test_fp2_prop_mul_inv_correct : forall a_315 : fp2 ,test_fp2_prop_mul_inv a_315 = true.
+Proof. Admitted.
+
 
 Definition test_extraction_issue  : bool :=
-  let b_324 :=
+  let b_317 :=
     fp2inv ((nat_mod_one , nat_mod_one )) in 
   (fp2fromfp (nat_mod_one )) =.? (
-    fp2mul ((nat_mod_one , nat_mod_one )) (b_324)).
-  
-  QuickChick (test_extraction_issue).
+    fp2mul ((nat_mod_one , nat_mod_one )) (b_317)).
+QuickChick (test_extraction_issue).
 
-Definition test_fp6_prop_mul_inv (a_325 : fp6) : bool :=
-  let b_326 :=
-    fp6inv (a_325) in 
-  (fp6fromfp2 (fp2fromfp (nat_mod_one ))) =.? (fp6mul (a_325) (b_326)).
-  
-  QuickChick (forAll g_fp6 (fun a_325 : fp6 =>test_fp6_prop_mul_inv a_325)).
 
-Definition test_fp6_prop_add_neg (a_327 : fp6) : bool :=
-  let b_328 :=
-    fp6neg (a_327) in 
-  (fp6fromfp2 (fp2fromfp (nat_mod_zero ))) =.? (fp6add (a_327) (b_328)).
-  
-  QuickChick (forAll g_fp6 (fun a_327 : fp6 =>test_fp6_prop_add_neg a_327)).
+Theorem test_extraction_issue_correct : test_extraction_issue = true.
+Proof. Admitted.
 
-Definition test_fp12_prop_add_neg (a_329 : fp12) : bool :=
-  let b_330 :=
-    fp12neg (a_329) in 
+
+Definition test_fp6_prop_mul_inv (a_318 : fp6) : bool :=
+  let b_319 :=
+    fp6inv (a_318) in 
+  (fp6fromfp2 (fp2fromfp (nat_mod_one ))) =.? (fp6mul (a_318) (b_319)).
+QuickChick (forAll g_fp6 (fun a_318 : fp6 =>test_fp6_prop_mul_inv a_318)).
+
+
+Theorem test_fp6_prop_mul_inv_correct : forall a_318 : fp6 ,test_fp6_prop_mul_inv a_318 = true.
+Proof. Admitted.
+
+
+Definition test_fp6_prop_add_neg (a_320 : fp6) : bool :=
+  let b_321 :=
+    fp6neg (a_320) in 
+  (fp6fromfp2 (fp2fromfp (nat_mod_zero ))) =.? (fp6add (a_320) (b_321)).
+QuickChick (forAll g_fp6 (fun a_320 : fp6 =>test_fp6_prop_add_neg a_320)).
+
+
+Theorem test_fp6_prop_add_neg_correct : forall a_320 : fp6 ,test_fp6_prop_add_neg a_320 = true.
+Proof. Admitted.
+
+
+Definition test_fp12_prop_add_neg (a_322 : fp12) : bool :=
+  let b_323 :=
+    fp12neg (a_322) in 
   (fp12fromfp6 (fp6fromfp2 (fp2fromfp (nat_mod_zero )))) =.? (
-    fp12add (a_329) (b_330)).
-  
-  QuickChick (forAll g_fp12 (fun a_329 : fp12 =>test_fp12_prop_add_neg a_329)).
+    fp12add (a_322) (b_323)).
+QuickChick (forAll g_fp12 (fun a_322 : fp12 =>test_fp12_prop_add_neg a_322)).
 
-Definition test_fp12_prop_mul_inv (a_331 : fp12) : bool :=
-  let b_332 :=
-    fp12inv (a_331) in 
+
+Theorem test_fp12_prop_add_neg_correct : forall a_322 : fp12 ,test_fp12_prop_add_neg a_322 = true.
+Proof. Admitted.
+
+
+Definition test_fp12_prop_mul_inv (a_324 : fp12) : bool :=
+  let b_325 :=
+    fp12inv (a_324) in 
   (fp12fromfp6 (fp6fromfp2 (fp2fromfp (nat_mod_one )))) =.? (
-    fp12mul (a_331) (b_332)).
-  
-  QuickChick (forAll g_fp12 (fun a_331 : fp12 =>test_fp12_prop_mul_inv a_331)).
+    fp12mul (a_324) (b_325)).
+QuickChick (forAll g_fp12 (fun a_324 : fp12 =>test_fp12_prop_mul_inv a_324)).
+
+
+Theorem test_fp12_prop_mul_inv_correct : forall a_324 : fp12 ,test_fp12_prop_mul_inv a_324 = true.
+Proof. Admitted.
+
 

--- a/examples/bls12-381/src/bls12-381.rs
+++ b/examples/bls12-381/src/bls12-381.rs
@@ -19,15 +19,6 @@ public_nat_mod!( //Custom Macro - defining a new type with some functions - well
     modulo_value: "8000000000000000000000000000000000000000000000000000000000000000" //0x8000000000000000000000000000000000000000000000000000000000000000
 );
 
-//Returns index of left-most bit, set to 1
-fn most_significant_bit(m: Scalar, n: usize) -> usize //usize does not have a secret integer implementation
-{
-    if n > 0 && !m.bit(n) {
-        most_significant_bit(m, n - 1)
-    } else {
-        n
-    }
-}
 //bool is "isPointAtInfinity"
 pub type G1 = (Fp, Fp, bool);
 pub type Fp2 = (Fp, Fp); //(10, 8) = (10+8u) : u² = -1
@@ -203,12 +194,11 @@ pub fn fp12inv(n: Fp12) -> Fp12 {
 }
 
 pub fn fp12exp(n: Fp12, k: Scalar) -> Fp12 {
-    let l = 255 - most_significant_bit(k, 255); //has a timing side channel issue
-    let mut c = n;
-    for i in l..255 {
+    let mut c = fp12fromfp6(fp6fromfp2(fp2fromfp(Fp::ONE())));
+    for i in 0..256 {
         //starting from second most significant bit
         c = fp12mul(c, c);
-        if k.bit(255 - i - 1) {
+        if k.bit(255 - i) {
             c = fp12mul(c, n);
         }
     }
@@ -283,13 +273,11 @@ pub fn g1add(p: G1, q: G1) -> G1 {
 }
 
 pub fn g1mul(m: Scalar, p: G1) -> G1 {
-    let n = 255;
-    let k = n - most_significant_bit(m, n); //has a timing side channel issue
-    let mut t = p;
-    for i in k..n {
+    let mut t = (Fp::ZERO(), Fp::ZERO(), true);
+    for i in 0..256 {
         //starting from second most significant bit
         t = g1double(t);
-        if m.bit(n - i - 1) {
+        if m.bit(255 - i) {
             t = g1add(t, p);
         }
     }
@@ -369,13 +357,11 @@ pub fn g2add(p: G2, q: G2) -> G2 {
 }
 
 pub fn g2mul(m: Scalar, p: G2) -> G2 {
-    let n = 255;
-    let k = n - most_significant_bit(m, n); //has a timing side channel issue
-    let mut t = p;
-    for i in k..n {
+    let mut t = (fp2zero(), fp2zero(), true);
+    for i in 0..256 {
         //starting from second most significant bit
         t = g2double(t);
-        if m.bit(n - i - 1) {
+        if m.bit(255 - i) {
             t = g2add(t, p);
         }
     }
@@ -647,12 +633,28 @@ fn test_fp12_prop_mul_inv(a: Fp12) -> bool {
 }
 
 #[cfg(test)]
-#[quickcheck]
-fn test_fp12_prop_exp(a: Fp12) -> bool {
-    let m = Scalar::from_literal(3u128);
-    let n = Scalar::from_literal(4u128);
-    let k = Scalar::from_literal(12u128);
-    fp12exp(fp12exp(a, m), n) == fp12exp(a, k)
+#[test]
+fn test_fp12_exp_zero() {
+    fn test_fp12_exp(a: Fp12) -> bool {
+        fp12fromfp6(fp6fromfp2(fp2fromfp(Fp::ONE()))) == fp12exp(a, Scalar::ZERO())
+    }
+    QuickCheck::new()
+        .tests(5)
+        .quickcheck(test_fp12_exp as fn(Fp12) -> bool);
+}
+
+#[cfg(test)]
+#[test]
+fn test_fp12_prop_exp() {
+    fn test_fp12_exp(a: Fp12) -> bool {
+        let m = Scalar::from_literal(3u128);
+        let n = Scalar::from_literal(4u128);
+        let k = Scalar::from_literal(12u128);
+        fp12exp(fp12exp(a, m), n) == fp12exp(a, k)
+    }
+    QuickCheck::new()
+        .tests(5)
+        .quickcheck(test_fp12_exp as fn(Fp12) -> bool);
 }
 
 /* G1 tests */
@@ -667,6 +669,31 @@ fn test_g1_arithmetic() {
     let g4b = g1add(g3, g);
     assert_eq!(g4a, g4b);
 }
+
+#[cfg(test)]
+#[test]
+fn test_g1_mul_standard()
+{
+    let g = g1();
+    let m = Scalar::ONE();
+    assert_eq!(g, g1mul(m, g));
+    let m = Scalar::from_literal(2u128);
+    let g2 = g1double(g);
+    assert_eq!(g2, g1mul(m, g));
+    let m = Scalar::from_literal(3u128);
+    let g3 = g1add(g, g2);
+    assert_eq!(g3, g1mul(m, g));
+}
+
+#[cfg(test)]
+#[test]
+fn test_g1_mul_zero()
+{
+    let g = g1();
+    let m = Scalar::ZERO();
+    let h = g1mul(m, g);
+    assert!(h.2);
+} 
 
 #[cfg(test)]
 #[test]
@@ -719,6 +746,31 @@ fn test_g2_arithmetic() {
 
 #[cfg(test)]
 #[test]
+fn test_g2_mul_standard()
+{
+    let g = g2();
+    let m = Scalar::ONE();
+    assert_eq!(g, g2mul(m, g));
+    let m = Scalar::from_literal(2u128);
+    let g2 = g2double(g);
+    assert_eq!(g2, g2mul(m, g));
+    let m = Scalar::from_literal(3u128);
+    let g3 = g2add(g, g2);
+    assert_eq!(g3, g2mul(m, g));
+}
+
+#[cfg(test)]
+#[test]
+fn test_g2_mul_zero()
+{
+    let g = g2();
+    let m = Scalar::ZERO();
+    let h = g2mul(m, g);
+    assert!(h.2);
+} 
+
+#[cfg(test)]
+#[test]
 fn test_g2_mul_prop() {
     fn test_g2_mul(a: Scalar) -> bool {
         let g = g2mul(a, g2());
@@ -736,14 +788,14 @@ fn test_g2_mul_prop() {
 #[cfg(test)]
 #[test]
 fn test_g2_add_double_equiv() {
-    fn test_g1_mul(a: Scalar) -> bool {
+    fn test_g2_mul(a: Scalar) -> bool {
         let g = g2mul(a, g2());
         g2add(g, g) == g2double(g)
     }
     //Only needing 5 successes, slow because affine
     QuickCheck::new()
         .tests(5)
-        .quickcheck(test_g1_mul as fn(Scalar) -> bool);
+        .quickcheck(test_g2_mul as fn(Scalar) -> bool);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I've removed the recursive function most_significant_bit from bls12-381.rs as I found out that recursive functions are not allowed in hacspec. 
This also fixes an issue where multiplying a curve point p with zero would give p instead of the point at infinity.