### PR TITLE
improve typechecker usability

### DIFF
--- a/language/Cargo.toml
+++ b/language/Cargo.toml
@@ -28,6 +28,8 @@ serde_json = "1.0"
 heck = "0.3.1"
 regex = "1.3.9"
 serde = { version = "1.0.125", features = ["derive"] }
+log = "0.4"
+pretty_env_logger = "0.4"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/language/src/bin.rs
+++ b/language/src/bin.rs
@@ -42,49 +42,50 @@ fn main() {
         args.remove(0);
     };
 
-    if args.len() < 1 {
-        println!("{}", APP_USAGE);
-        std::process::exit(1);
+    if let Some(arg0) = args.get(0) {
+        if arg0 == "--help" || arg0 == "-h" {
+            println!("{}", APP_USAGE);
+            std::process::exit(1);
+        }
     }
 
     let environment: HashMap<String, String> = env::vars().collect();
 
     let file_paths = match args.iter().position(|a| a == "-o") {
-        Some(j) => {
-            match args.get(j + 1).cloned() {
-                Some (file) => {
-                    let file_parent = std::path::Path::new(&file).parent().unwrap();
-                    let file_stem = std::path::Path::new(&file).file_stem().unwrap();
-                    let file_extension = std::path::Path::new(&file).extension().and_then(std::ffi::OsStr::to_str).unwrap();
+        Some(j) => match args.get(j + 1).cloned() {
+            Some(file) => {
+                let file_parent = std::path::Path::new(&file).parent().unwrap();
+                let file_stem = std::path::Path::new(&file).file_stem().unwrap();
+                let file_extension = std::path::Path::new(&file)
+                    .extension()
+                    .and_then(std::ffi::OsStr::to_str)
+                    .unwrap();
 
-                    let file_prefix = file_parent.join(file_stem);
-                    let file_prefix = file_prefix.to_str().unwrap();
-                    
-                    let template_path = file_prefix.to_string() + "_template." + file_extension;
-                    let temp_path = file_prefix.to_string() + "_temp." + file_extension;
+                let file_prefix = file_parent.join(file_stem);
+                let file_prefix = file_prefix.to_str().unwrap();
 
-                    match args.iter().position(|a| a == "--init") {
+                let template_path = file_prefix.to_string() + "_template." + file_extension;
+                let temp_path = file_prefix.to_string() + "_temp." + file_extension;
+
+                match args.iter().position(|a| a == "--init") {
+                    Some(i) => {
+                        args.remove(i);
+                        Some((file, temp_path, template_path, true))
+                    }
+                    None => match args.iter().position(|a| a == "--update") {
                         Some(i) => {
                             args.remove(i);
-                            Some ((file, temp_path, template_path, true))
+                            args.remove(j + 1);
+                            args.insert(j + 1, temp_path.clone());
+                            Some((file, temp_path, template_path, false))
                         }
-                        None => {
-                            match args.iter().position(|a| a == "--update") {
-                                Some(i) => {
-                                    args.remove(i);
-                                    args.remove(j+1);
-                                    args.insert(j+1, temp_path.clone());
-                                    Some ((file, temp_path, template_path, false))
-                                }
-                                None => None,
-                            }
-                        }
-                    }
+                        None => None,
+                    },
                 }
-                None => None,
             }
+            None => None,
         },
-        None => None
+        None => None,
     };
 
     let hacspec_out = std::process::Command::new(driver())
@@ -94,14 +95,20 @@ fn main() {
         .args(args)
         .status()
         .expect("Couldn't run hacspec");
-    
+
     match file_paths {
-        Some ((file, _, template, true)) => {
-            std::fs::copy(file.clone(), template.clone())
-                .expect(format!("Failed to copy file '{}' to '{}'", file.clone(), template.clone()).as_str());
+        Some((file, _, template, true)) => {
+            std::fs::copy(file.clone(), template.clone()).expect(
+                format!(
+                    "Failed to copy file '{}' to '{}'",
+                    file.clone(),
+                    template.clone()
+                )
+                .as_str(),
+            );
             ()
         }
-        Some ((file, temp, template, false)) => {
+        Some((file, temp, template, false)) => {
             std::process::Command::new("git")
                 .output()
                 .expect("Could not find 'git'. Please install git and try again.");
@@ -112,12 +119,20 @@ fn main() {
                 .arg(temp.clone())
                 .output()
                 .expect("git-merge failed");
-            std::fs::copy(temp.clone(), template.clone()).expect(format!("Failed to copy file '{}' to '{}'", temp.clone(), template.clone()).as_str());
-            std::fs::remove_file(temp.clone()).expect(format!("Failed to remove file '{}'", file.clone()).as_str());
+            std::fs::copy(temp.clone(), template.clone()).expect(
+                format!(
+                    "Failed to copy file '{}' to '{}'",
+                    temp.clone(),
+                    template.clone()
+                )
+                .as_str(),
+            );
+            std::fs::remove_file(temp.clone())
+                .expect(format!("Failed to remove file '{}'", file.clone()).as_str());
             ()
         }
-        None => ()
+        None => (),
     };
-    
+
     std::process::exit(hacspec_out.code().unwrap());
 }

--- a/language/src/main.rs
+++ b/language/src/main.rs
@@ -67,6 +67,8 @@ impl HacspecErrorEmitter for Session {
 
 impl Callbacks for HacspecCallbacks {
     fn config(&mut self, config: &mut Config) {
+        log::debug!(" --- hacspec config callback");
+        log::trace!("     target directory {}", self.target_directory);
         config.opts.search_paths.push(SearchPath::from_cli_opt(
             &self.target_directory,
             ERROR_OUTPUT_CONFIG,
@@ -82,6 +84,7 @@ impl Callbacks for HacspecCallbacks {
         compiler: &Compiler,
         queries: &'tcx Queries<'tcx>,
     ) -> Compilation {
+        log::debug!(" --- hacspec after_analysis callback");
         let krate = queries.parse().unwrap().take();
         let external_data = |imported_crates: &Vec<rustspec::Spanned<String>>| {
             queries.global_ctxt().unwrap().peek_mut().enter(|tcx| {
@@ -226,39 +229,62 @@ struct Manifest {
 // ===
 
 /// Read the crate metadata and use the information for the build.
-fn read_crate(package_name: String, args: &mut Vec<String>, callbacks: &mut HacspecCallbacks) {
+fn read_crate(
+    manifest: Option<String>,
+    package_name: Option<String>,
+    args: &mut Vec<String>,
+    callbacks: &mut HacspecCallbacks,
+) {
     let manifest: Manifest = {
         let mut output = Command::new("cargo");
-        let output = output
-            .arg("metadata")
-            .args(&["--no-deps", "--format-version", "1"]);
-        let output = output.output().expect("Error reading cargo manifest.");
+        let mut output_args = if let Some(manifest_path) = manifest {
+            vec!["--manifest-path".to_string(), manifest_path]
+        } else {
+            Vec::<String>::new()
+        };
+        output_args.extend_from_slice(&[
+            "--no-deps".to_string(),
+            "--format-version".to_string(),
+            "1".to_string(),
+        ]);
+        let output = output.arg("metadata").args(&output_args);
+        let output = output.output().expect(" ⚠️  Error reading cargo manifest.");
         let stdout = output.stdout;
         if !output.status.success() {
             let error =
-                String::from_utf8(output.stderr).expect("Failed reading cargo stderr output");
+                String::from_utf8(output.stderr).expect(" ⚠️  Failed reading cargo stderr output");
             panic!("Error running cargo metadata: {:?}", error);
         }
-        let json_string = String::from_utf8(stdout).expect("Failed reading cargo output");
-        serde_json::from_str(&json_string).expect("Error reading to manifest")
+        let json_string = String::from_utf8(stdout).expect(" ⚠️  Failed reading cargo output");
+        serde_json::from_str(&json_string).expect(" ⚠️  Error reading to manifest")
     };
 
-    // Pick the package of the given name.
-    let package = manifest
-        .packages
-        .iter()
-        .find(|p| p.name == package_name)
-        .expect(&format!(
-            "Can't find the package {} in the Cargo.toml",
-            package_name
-        ));
+    // Pick the package of the given name or the only package available.
+    let package = if let Some(package_name) = package_name {
+        manifest
+            .packages
+            .iter()
+            .find(|p| p.name == package_name)
+            .expect(&format!(
+                " ⚠️  Can't find the package {} in the Cargo.toml\n\n{}",
+                package_name, APP_USAGE,
+            ))
+    } else {
+        &manifest.packages[0]
+    };
+    log::trace!("Typechecking '{:?}' ...", package);
 
     // Take the first lib target we find. There should be only one really.
+    // log::trace!("crate types: {:?}", package.targets);
+    // log::trace!("package targets {:?}", package.targets);
     let target = package
         .targets
         .iter()
-        .find(|p| p.crate_types.contains(&"lib".to_string()))
-        .expect("No target in the Cargo.toml");
+        .find(|p| {
+            p.crate_types.contains(&"lib".to_string())
+                || p.crate_types.contains(&"rlib".to_string())
+        })
+        .expect(&format!(" ⚠️  No target in the Cargo.toml\n\n{}", APP_USAGE));
 
     // Add the target source file to the arguments
     args.push(target.src_path.clone());
@@ -274,11 +300,24 @@ fn read_crate(package_name: String, args: &mut Vec<String>, callbacks: &mut Hacs
     }
 }
 
-fn main() -> Result<(), ()> {
+fn main() -> Result<(), usize> {
+    pretty_env_logger::init();
+    log::debug!(" --- hacspec");
     let mut args = env::args().collect::<Vec<String>>();
+
+    // Args to pass to the compiler
+    let mut compiler_args = Vec::new();
+
+    // Drop and pass along binary name.
+    compiler_args.push(args.remove(0));
+
+    // Optionally get output file.
     let output_file_index = args.iter().position(|a| a == "-o");
     let output_file = match output_file_index {
-        Some(i) => args.get(i + 1).cloned(),
+        Some(i) => {
+            args.remove(i);
+            Some(args.remove(i))
+        }
         None => None,
     };
 
@@ -292,6 +331,24 @@ fn main() -> Result<(), ()> {
         None => false,
     };
 
+    // Read the --manifest-path argument if present.
+    let manifest = match args.iter().position(|a| a == "--manifest-path") {
+        Some(i) => {
+            args.remove(i);
+            Some(args.remove(i))
+        }
+        None => None,
+    };
+
+    // Read the --sysroot. It must be present
+    log::trace!("args: {:?}", args);
+    match args.iter().position(|a| a.starts_with("--sysroot")) {
+        Some(i) => {
+            compiler_args.push(args.remove(i));
+        }
+        None => panic!(" ⚠️  --sysroot is missing. Please report this issue."),
+    }
+
     let mut callbacks = HacspecCallbacks {
         output_file,
         // This defaults to the default target directory.
@@ -300,14 +357,12 @@ fn main() -> Result<(), ()> {
     };
 
     if !input_file {
-        let package_name = args
-            .pop()
-            .expect(&format!("No package to analyze.\n\n{}", APP_USAGE));
-
-        read_crate(package_name, &mut args, &mut callbacks);
+        let package_name = args.pop();
+        log::trace!("package name to analyze: {:?}", package_name);
+        read_crate(manifest, package_name, &mut compiler_args, &mut callbacks);
     } else {
         // If only a file is provided we add the default dependencies only.
-        args.extend_from_slice(&[
+        compiler_args.extend_from_slice(&[
             "--extern=abstract_integers".to_string(),
             "--extern=hacspec_derive".to_string(),
             "--extern=hacspec_lib".to_string(),
@@ -315,11 +370,13 @@ fn main() -> Result<(), ()> {
         ]);
     }
 
-    args.push("--crate-type=lib".to_string());
-    args.push("--edition=2018".to_string());
+    compiler_args.push("--crate-type=lib".to_string());
+    compiler_args.push("--edition=2021".to_string());
+    log::trace!("compiler_args: {:?}", compiler_args);
+    let compiler = RunCompiler::new(&compiler_args, &mut callbacks);
 
-    match RunCompiler::new(&args, &mut callbacks).run() {
+    match compiler.run() {
         Ok(_) => Ok(()),
-        Err(_) => Err(()),
+        Err(_) => Err(1),
     }
 }

--- a/language/src/util.rs
+++ b/language/src/util.rs
@@ -1,20 +1,27 @@
-pub(crate) const APP_USAGE: &'static str = "Hacspec 0.1.0
-Hacspec Developers
-Typechecker and compiler for the Hacspec subset of Rust
+pub(crate) const APP_USAGE: &'static str = "hacspec 0.1.0
+hacspec Developers
+Typechecker and compiler for the hacspec subset of Rust
 
 USAGE:
-    cargo hacspec [FLAGS] [OPTIONS] <CRATE>
+    cargo hacspec [FLAGS] [OPTIONS] [CRATE]
 
 FLAGS:
     -v               Verbosity
     --init           Creates a '<output>_template' file along with the output
     --update         Merges changes into output file based on the template file
+    --manifest-path  The cargo manifest path argument. The typechecker will analyze
+                     the crate or workspace at the specified Cargo.toml.
+                     Note that you have to specify the path including the Cargo.toml
+                     file!
 
 OPTIONS:
     -o <FILE>        Name of the F* (.fst), Easycrypt (.ec), or Coq (.v) output file
 
 ARGS:
-    CRATE            The crate to analyse
+    CRATE            The crate to analyse.
+                     The crate name is required if there are multiple crates in the
+                     workspace. If only one crate is present, the argument can be
+                     omitted.
 ";
 
 #[allow(dead_code)]


### PR DESCRIPTION
A first batch of basic typechecker usability improvements.

- support [--manifest-path argument](https://doc.rust-lang.org/cargo/commands/cargo-build.html#manifest-options)
- don't require crate name if only one crate is available
- slightly better errors
- support crates that specify the [crate-type](https://doc.rust-lang.org/cargo/reference/cargo-targets.html)