### PR TITLE
Run only release tests on examples

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -18,11 +18,11 @@ jobs:
           submodules: true
       - name: Build
         run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
+      - name: Run library tests
+        run: cargo test --verbose -p hacspec-lib
       - name: Test Provider
         run: cargo test --verbose -p rc-tests
       - name: Get hacspec function stats
         run: RUST_NIGHTLY=nightly-2021-11-14 ./lib/get_func_stats.sh
       - name: Build and test Hacspec compiler
-        run: cargo clean && cargo build -p hacspec-lib &&  cd language && cargo test --verbose
+        run: cargo clean && cargo build -p hacspec-lib && cd language && cargo test --verbose

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,22 @@
+name: Test Examples
+
+on: [push, pull_request, release]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Build release
+        run: cargo build --verbose --release
+      - name: Run release tests
+        run: cargo test --verbose --release

--- a/language/src/rustspec_to_fstar.rs
+++ b/language/src/rustspec_to_fstar.rs
@@ -229,8 +229,16 @@ fn translate_ident_str<'a>(ident_str: String) -> RcDoc<'a, ()> {
     RcDoc::as_string(snake_case_ident)
 }
 
+fn uppercase_first_letter(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
+}
+
 fn translate_constructor<'a>(enum_name: TopLevelIdent) -> RcDoc<'a> {
-    RcDoc::as_string(enum_name.string)
+    RcDoc::as_string(uppercase_first_letter(&enum_name.string))
 }
 
 fn translate_enum_name<'a>(enum_name: TopLevelIdent) -> RcDoc<'a> {
@@ -246,7 +254,7 @@ fn translate_enum_case_name<'a>(enum_name: BaseTyp, case_name: TopLevelIdent) ->
                 RcDoc::as_string("_").append(translate_toplevel_ident(name.0))
             }
         }
-        _ => panic!("shoud not happen"),
+        _ => panic!("should not happen"),
     })
 }
 


### PR DESCRIPTION
The main purpose of this PR is to make the CI faster by running the example tests only in release mode.

But I also slipped in the `uppercase_first_letter` function to force upper case in F* for now. @denismerigoux let me know if you're happy with this. I know it's not ideal and we should make this nicer. But this way we don't break the generated F* code all the time (in this way).