### PR TITLE
Macro support

### DIFF
--- a/language/src/main.rs
+++ b/language/src/main.rs
@@ -315,7 +315,7 @@ fn handle_crate<'tcx>(
             Err(_) => {
                 compiler
                     .session()
-                    .err("unable to translate to Hacspec due to out-of-language errors");
+                    .err("found some Hacspec name resolution errors");
                 return Compilation::Stop;
             }
         };

--- a/language/src/main.rs
+++ b/language/src/main.rs
@@ -549,20 +549,6 @@ impl Callbacks for HacspecCallbacks {
         {
             let krate_and_resolver = queries.expansion().unwrap().peek_mut().clone(); // ?
             expanded_krate = (*krate_and_resolver.0).clone();
-
-            // let mut resolver = (*krate_and_resolver.1).into_inner();
-            // resolver.access(|resolver| {
-
-            //     let krate_name = queries.crate_name().unwrap().peek().clone();
-            //     let mut ext_ctxt = rustc_expand::base::ExtCtxt::new(
-            //         &compiler.session(),
-            //         rustc_expand::expand::ExpansionConfig::default(krate_name),
-            //         resolver,
-            //         None);
-
-            // let mut macro_expander : rustc_expand::expand::MacroExpander = ext_ctxt.expander();
-            //     krate = macro_expander.expand_crate(krate.clone());
-            // });
         }
 
         queries.prepare_outputs().unwrap(); // ?
@@ -599,10 +585,7 @@ impl Callbacks for HacspecCallbacks {
                     }
                     // Invariant, the second parameter is up to date at this moment
                     (
-                        rustc_ast::ast::ItemKind::MacCall(rustc_ast::ast::MacCall {
-                            path,
-                            ..
-                        }),
+                        rustc_ast::ast::ItemKind::MacCall(rustc_ast::ast::MacCall { path, .. }),
                         _,
                     ) => {
                         let push_in_loop = match path
@@ -614,7 +597,12 @@ impl Callbacks for HacspecCallbacks {
                             .to_ident_string()
                             .as_str()
                         {
-                            "secret_array" | "array" | "public_nat_mod" => {
+                            "array"
+                            | "bytes"
+                            | "public_bytes"
+                            | "public_nat_mod"
+                            | "nat_mod"
+                            | "unsigned_public_integer" => {
                                 items.push(krate.items[index].clone());
                                 false
                             }
@@ -662,8 +650,13 @@ impl Callbacks for HacspecCallbacks {
             krate.items = items;
         }
 
-        let crate_origin_file = compiler.build_output_filenames(compiler.session(), &[]).with_extension("").to_str().unwrap().to_string();
-        
+        let crate_origin_file = compiler
+            .build_output_filenames(compiler.session(), &[])
+            .with_extension("")
+            .to_str()
+            .unwrap()
+            .to_string();
+
         let mut analysis_crates = HashMap::new();
         analysis_crates.insert(crate_origin_file.clone(), krate);
 

--- a/language/src/main.rs
+++ b/language/src/main.rs
@@ -611,7 +611,7 @@ impl Callbacks for HacspecCallbacks {
             let mut items = vec![];
 
             let mut index = 0;
-            let mut index_expand = 1; // Skip use std?
+            let mut index_expand = 0; // Skip use std? = 1
 
             while index < krate.items.len() && index_expand < expanded_krate.items.len() {
                 // Merge trees removing macro calls when not hacspec calls
@@ -619,6 +619,9 @@ impl Callbacks for HacspecCallbacks {
                     krate.items[index].kind.clone(),
                     expanded_krate.items[index_expand].kind.clone(),
                 ) {
+                    (rustc_ast::ast::ItemKind::ExternCrate(..), _) => {
+                        index += 1;
+                    }
                     (_, rustc_ast::ast::ItemKind::ExternCrate(..)) => {
                         index_expand += 1;
                     }


### PR DESCRIPTION
This is a bit hacky implementation to support macros given by `macro_rules!` in hacspec. A better alternative would probably supporting `proc_macro!`. An example implementation of the sha family using macros can be found at [macro_sha256/512](https://github.com/cmester0/hacspec/blob/macro_sha256/512/examples/sha256/src/hacspec-sha256.rs). 

Implementation makes use of expanded ast instead of just parsed ast, followed by some pattern matching to raise some elements back, which is the hacky part of the implementation.