### PR TITLE
language: pin "im" dependency to 15.0.x

### DIFF
--- a/language/Cargo.toml
+++ b/language/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 hacspec-util = { path = "../utils/util", version = "0.1.0-beta.1" }
 pretty = "0.10.0"
-im = "15.0.0"
+im = "~15.0.0"
 itertools = "0.10.0"
 lazy_static = "1.4.0"
 walkdir = "2.3.1"


### PR DESCRIPTION
Seems like "im" version  15.1.0 broke something. See #247 and #72.

This PR pins "im" to 15.0.x.