### PR TITLE
set `resolver = "2"` in workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,4 @@ default-members = [
     "examples/sha512",
 ]
 exclude = [ "language" ]
+resolver = "2"


### PR DESCRIPTION
The old resolver doesn't allow testing with `--no-default-features`, e.g., doing

    cargo build --target thumbv7em-none-eabi -p hacspec-lib --no-default-features --features alloc

See #72.

This PR sets the workspace resolver to "2".