### PR TITLE
Update im

### DIFF
--- a/language/Cargo.toml
+++ b/language/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 hacspec-util = { path = "../utils/util", version = "0.1.0-beta.1" }
 pretty = "0.10.0"
-im = "~15.0.0"
+im = "15.1"
 itertools = "0.10.0"
 lazy_static = "1.4.0"
 walkdir = "2.3.1"


### PR DESCRIPTION
There are tests that fail with the updated im. 
An easy way to reproduce this is updating im and then running hacspec with `-f language-tests/enums.r`.