### PR TITLE
fix im union

### DIFF
--- a/language/Cargo.toml
+++ b/language/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 hacspec-util = { path = "../utils/util", version = "0.1.0-beta.1" }
 pretty = "0.10.0"
-im = "~15.0.0"
+im = "~15.1.0"
 itertools = "0.10.0"
 lazy_static = "1.4.0"
 walkdir = "2.3.1"
@@ -30,6 +30,10 @@ regex = "1.3.9"
 serde = { version = "1.0.125", features = ["derive"] }
 log = "0.4"
 pretty_env_logger = "0.4"
+backtrace = { version = "0.3", optional = true }
+
+[features]
+dev = [ "backtrace" ]
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/language/language-tests/enums.rs
+++ b/language/language-tests/enums.rs
@@ -19,3 +19,9 @@ pub fn baz(x: Foo) -> Bar {
         Foo::CaseY(a, _b) => Bar(U32_from_U8(a).declassify()),
     }
 }
+
+pub fn baz_im(x: Foo) {
+    let z: Bar = Bar(0u32);
+    let Bar(z) = z;
+    let _a = z as u8;
+}

--- a/language/src/ast_to_rustspec.rs
+++ b/language/src/ast_to_rustspec.rs
@@ -18,7 +18,7 @@ use crate::hir_to_rustspec::ExternalData;
 use crate::rustspec::*;
 use crate::HacspecErrorEmitter;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SpecialNames {
     pub arrays: HashSet<String>,
     pub enums: HashSet<String>,
@@ -1192,6 +1192,7 @@ fn translate_expr(
             Err(())
         }
         ExprKind::Cast(e1, t1) => {
+            log::trace!("   ExprKind::Cast {:?} -> {:?}", e1, t1);
             let new_e1 = translate_expr_expects_exp(sess, specials, e1)?;
             let new_t1 = translate_base_typ(sess, t1)?;
             Ok((
@@ -1764,6 +1765,7 @@ fn translate_block(
     ))
 }
 
+#[derive(Debug)]
 enum ItemTranslationResult {
     Item(DecoratedItem),
     Ignored,
@@ -2401,6 +2403,7 @@ fn translate_items<F: Fn(&Vec<Spanned<String>>) -> ExternalData>(
     specials: &SpecialNames,
     external_data: &F,
 ) -> TranslationResult<(ItemTranslationResult, SpecialNames)> {
+    log::trace!("translate_items ({:?})", i);
     let mut tags = HashSet::new();
     tags.insert("code".to_string());
     let export = i
@@ -2526,6 +2529,7 @@ fn translate_items<F: Fn(&Vec<Spanned<String>>) -> ExternalData>(
                 ),
                 Some(b) => translate_block(sess, specials, &b)?,
             };
+            log::trace!("   fn_body: {:#?}", fn_body);
             let fn_sig = FuncSig {
                 args: fn_inputs,
                 ret: fn_output,
@@ -2892,6 +2896,7 @@ pub fn translate<F: Fn(&Vec<Spanned<String>>) -> ExternalData>(
     external_data: &F,
     specials: &mut SpecialNames,
 ) -> TranslationResult<Program> {
+    log::trace!("translate ({:?})", krate);
     let items = &krate.items;
     let translated_items = check_vec(
         items

--- a/language/src/main.rs
+++ b/language/src/main.rs
@@ -339,6 +339,7 @@ fn handle_crate<'tcx>(
 
     let mut krate_queue_typechecked = Vec::new();
     for ((krate_path, krate_dir, krate_module_string), krate) in krate_queue_programs {
+        log::trace!("   typechecking {:#?}", krate);
         let new_top_ctx = &mut name_resolution::TopLevelContext {
             consts: HashMap::new(),
             functions: HashMap::new(),

--- a/language/src/rustspec.rs
+++ b/language/src/rustspec.rs
@@ -172,7 +172,7 @@ impl fmt::Debug for TypVar {
     }
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Serialize)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Debug)]
 pub enum BaseTyp {
     Unit,
     Bool,
@@ -259,11 +259,11 @@ impl fmt::Display for BaseTyp {
     }
 }
 
-impl fmt::Debug for BaseTyp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
-    }
-}
+// impl fmt::Debug for BaseTyp {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//         write!(f, "{}", self)
+//     }
+// }
 
 pub type Typ = (Spanned<Borrowing>, Spanned<BaseTyp>);
 
@@ -454,7 +454,7 @@ pub struct ExternalFuncSig {
     pub ret: BaseTyp,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, Debug)]
 pub enum Item {
     FnDecl(Spanned<TopLevelIdent>, FuncSig, Spanned<Block>),
     EnumDecl(
@@ -484,7 +484,7 @@ pub enum Item {
 
 pub type ItemTag = String;
 
-#[derive(Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug)]
 pub struct ItemTagSet(pub HashSet<ItemTag>);
 
 impl Serialize for ItemTagSet {
@@ -500,13 +500,13 @@ impl Serialize for ItemTagSet {
     }
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, Debug)]
 pub struct DecoratedItem {
     pub item: Item,
     pub tags: ItemTagSet,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, Debug)]
 pub struct Program {
     pub items: Vec<Spanned<DecoratedItem>>,
 }

--- a/language/src/typechecker.rs
+++ b/language/src/typechecker.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use crate::name_resolution::{DictEntry, FnKey, FnValue, TopLevelContext};
 use crate::rustspec::*;
 use crate::util::check_vec;
@@ -205,6 +207,7 @@ fn is_index(t: &BaseTyp, top_ctxt: &TopLevelContext) -> bool {
 
 fn is_castable_integer(t: &BaseTyp, top_ctxt: &TopLevelContext) -> bool {
     let t = dealias_type(t.clone(), top_ctxt);
+    log::trace!("is_castable_integer {}", t);
     match t {
         BaseTyp::UInt128 => true,
         BaseTyp::Int128 => true,
@@ -294,7 +297,7 @@ fn unify_types(
                     typ_ctx,
                     top_ctx,
                 );
-            },
+            }
             _ => (),
         },
         _ => (),
@@ -329,7 +332,7 @@ fn unify_types(
         },
         _ => (),
     }
-    
+
     match (&(t1.0).0, &(t2.0).0) {
         (Borrowing::Consumed, Borrowing::Consumed) | (Borrowing::Borrowed, Borrowing::Borrowed) => {
             match (&(t1.1).0, &(t2.1).0) {
@@ -615,6 +618,7 @@ fn find_typ(
     var_context: &VarContext,
     top_level_context: &TopLevelContext,
 ) -> Option<Typ> {
+    log::trace!("find_typ {}", x);
     match x {
         Ident::Unresolved(_) => panic!("name resolution should have already happened"),
         Ident::TopLevel(name) => top_level_context.consts.get(name).map(|(t, span)| {
@@ -635,6 +639,7 @@ fn remove_var(x: &Ident, var_context: &VarContext) -> VarContext {
 }
 
 fn add_var(x: &Ident, typ: &Typ, var_context: &VarContext) -> VarContext {
+    log::trace!("add_var {} of type {:?}", x, typ);
     match x {
         Ident::Local(LocalIdent { id, name }) => {
             var_context.update(id.clone(), (typ.clone(), name.clone()))
@@ -651,6 +656,9 @@ fn typecheck_expression(
     top_level_context: &TopLevelContext,
     var_context: &VarContext,
 ) -> TypecheckingResult<(Expression, Typ, VarContext)> {
+    log::trace!("typecheck_expression {:?} ({:?})", e, span);
+    #[cfg(feature = "dev")]
+    log::trace!("   {:?}", backtrace::Backtrace::new());
     match e {
         Expression::Tuple(args) => {
             let mut var_context = var_context.clone();
@@ -684,6 +692,7 @@ fn typecheck_expression(
             ))
         }
         Expression::Named(id) => {
+            log::trace!("    named {}", id);
             let new_path = Expression::Named(id.clone());
             match find_typ(&id, var_context, top_level_context) {
                 None => {
@@ -694,15 +703,19 @@ fn typecheck_expression(
                     Err(())
                 }
                 Some(t) => {
+                    log::trace!("    t {:?}", t);
                     // This is where linearity kicks in
                     if let Borrowing::Consumed = (t.0).0 {
                         if is_copy(&(t.1).0, top_level_context) {
+                            log::trace!("    Copied - new path: {:?}", new_path);
                             Ok((new_path, t.clone(), var_context.clone()))
                         } else {
+                            log::trace!("    Consumed - new path: {:?}", new_path);
                             let new_var_context = remove_var(&id, var_context);
                             Ok((new_path, t.clone(), new_var_context))
                         }
                     } else {
+                        log::trace!("    Just cloned - new path: {:?}", new_path);
                         Ok((new_path, t.clone(), var_context.clone()))
                     }
                 }
@@ -839,7 +852,9 @@ fn typecheck_expression(
                                     )?;
                                     match new_typ_var_ctx {
                                         Some(new_typ_var_ctx) => {
-                                            typ_var_ctx = typ_var_ctx.union(new_typ_var_ctx);
+                                            for (k, v) in new_typ_var_ctx.into_iter() {
+                                                typ_var_ctx = typ_var_ctx.update(k, v);
+                                            }
                                         }
                                         None => {
                                             sess.span_rustspec_err(
@@ -1617,14 +1632,14 @@ fn typecheck_expression(
             let mut new_arg_types = Vec::new();
             for (sig_t, ((arg, arg_span), (arg_borrow, arg_borrow_span))) in
                 sig_args.iter().zip(args)
-            {   
+            {
                 let (new_arg, arg_t, new_var_context) = typecheck_expression(
                     sess,
                     &(arg.clone(), arg_span.clone()),
                     top_level_context,
                     &var_context,
                 )?;
-                
+
                 let new_arg_t = match (&(arg_t.0).0, &arg_borrow) {
                     (Borrowing::Borrowed, Borrowing::Borrowed) => {
                         sess.span_rustspec_err(
@@ -1654,12 +1669,12 @@ fn typecheck_expression(
                         arg_t.clone()
                     }
                 };
-                
+
                 new_args.push((
                     (new_arg, arg_span.clone()),
                     (arg_borrow.clone(), arg_borrow_span.clone()),
                 ));
-                new_arg_types.push(new_arg_t.1.0.clone());
+                new_arg_types.push(new_arg_t.1 .0.clone());
                 match unify_types(sess, &new_arg_t, sig_t, &typ_var_ctx, top_level_context)? {
                     None => {
                         sess.span_rustspec_err(
@@ -1800,7 +1815,7 @@ fn typecheck_expression(
                     (new_arg, arg_span.clone()),
                     (arg_borrow.clone(), arg_borrow_span.clone()),
                 ));
-                new_arg_types.push(new_arg_t.1.0.clone());
+                new_arg_types.push(new_arg_t.1 .0.clone());
                 match unify_types(sess, &new_arg_t, sig_t, &typ_var_ctx, top_level_context)? {
                     None => {
                         sess.span_rustspec_err(
@@ -1840,12 +1855,16 @@ fn typecheck_expression(
             ))
         }
         Expression::IntegerCasting(e1, t1, _) => {
+            log::trace!("Expression::IntegerCasting {:?} - {:?}", e1, t1);
+            // log::trace!("         top level context {}", top_level_context);
+            // log::trace!("          variable context {:?}", var_context);
             let (new_e1, e1_typ, var_context) =
                 typecheck_expression(sess, e1, top_level_context, var_context)?;
             if (e1_typ.0).0 == Borrowing::Borrowed {
                 sess.span_rustspec_err(e1.1.clone(), "cannot cast borrowed expression");
                 return Err(());
             }
+            log::trace!("   e1 type {:?}", e1_typ);
             if !is_castable_integer(&(e1_typ.1).0, top_level_context) {
                 sess.span_rustspec_err(
                     e1.1.clone(),
@@ -1872,12 +1891,14 @@ fn typecheck_expression(
                     .as_str(),
                 );
             }
+            let expr = Expression::IntegerCasting(
+                Box::new((new_e1, e1.1.clone())),
+                t1.clone(),
+                Some((e1_typ.1).0.clone()),
+            );
+            log::trace!("   casting expression {:?}", expr);
             Ok((
-                Expression::IntegerCasting(
-                    Box::new((new_e1, e1.1.clone())),
-                    t1.clone(),
-                    Some((e1_typ.1).0.clone()),
-                ),
+                expr,
                 ((Borrowing::Consumed, t1.1.clone()), t1.clone()),
                 var_context,
             ))
@@ -2047,6 +2068,7 @@ fn var_set_to_tuple(vars: &VarSet, span: &RustspecSpan) -> Statement {
 }
 
 fn dealias_type(ty: BaseTyp, top_level_context: &TopLevelContext) -> BaseTyp {
+    log::trace!("dealias_type {:?}", ty);
     match &ty {
         BaseTyp::Named((name, _), None) => match top_level_context.typ_dict.get(name) {
             Some((((Borrowing::Consumed, _), (aliased_ty, _)), DictEntry::Alias)) => {
@@ -2218,8 +2240,13 @@ fn typecheck_statement(
     var_context: &VarContext,
     return_typ: &Spanned<BaseTyp>,
 ) -> TypecheckingResult<(Statement, Typ, VarContext, VarSet)> {
+    log::trace!("typecheck_statement ({:?}, {:?})", s, s_span);
     match &s {
         Statement::LetBinding((pat, pat_span), typ, ref expr, question_mark) => {
+            log::trace!("   Statement::LetBinding");
+            log::trace!("       expr: {:?}", expr);
+            #[cfg(feature = "dev")]
+            log::trace!("   {:?}", backtrace::Backtrace::new());
             let (new_expr, expr_typ, new_var_context) =
                 typecheck_expression(sess, expr, top_level_context, var_context)?;
             let expr_typ = typecheck_question_mark(
@@ -2259,12 +2286,18 @@ fn typecheck_statement(
                     typ.clone()
                 }
             };
+            log::trace!("   typ: {:?}", typ);
             let pat_var_context = typecheck_pattern(
                 sess,
                 &(pat.clone(), pat_span.clone()),
                 &expr_typ,
                 top_level_context,
             )?;
+            log::trace!("   pat_var_context: {:?}", pat_var_context);
+            log::trace!(
+                "   new_var_context: {:?}",
+                new_var_context.clone().union(pat_var_context.clone())
+            );
             Ok((
                 Statement::LetBinding(
                     (pat.clone(), pat_span.clone()),
@@ -2278,6 +2311,7 @@ fn typecheck_statement(
             ))
         }
         Statement::Reassignment((x, x_span), e, question_mark) => {
+            log::trace!("   Statement::Reassignment");
             let (new_e, e_typ, new_var_context) =
                 typecheck_expression(sess, &e, top_level_context, var_context)?;
             let e_typ = typecheck_question_mark(
@@ -2321,6 +2355,7 @@ fn typecheck_statement(
             ))
         }
         Statement::ArrayUpdate((x, x_span), e1, e2, question_mark, _) => {
+            log::trace!("   Statement::ArrayUpdate");
             let (new_e1, e1_t, var_context) =
                 typecheck_expression(sess, &e1, top_level_context, var_context)?;
             let (new_e2, e2_t, var_context) =
@@ -2389,6 +2424,7 @@ fn typecheck_statement(
             ))
         }
         Statement::ReturnExp(e) => {
+            log::trace!("   Statement::ReturnExp");
             let (new_e, e_t, var_context) =
                 typecheck_expression(sess, &(e.clone(), s_span), top_level_context, var_context)?;
             Ok((
@@ -2399,6 +2435,7 @@ fn typecheck_statement(
             ))
         }
         Statement::Conditional(cond, (b1, b1_span), b2, _) => {
+            log::trace!("   Statement::Conditional");
             let original_var_context = var_context;
             let (new_cond, cond_t, var_context) =
                 typecheck_expression(sess, &cond, top_level_context, var_context)?;
@@ -2485,7 +2522,10 @@ fn typecheck_statement(
                     new_b2,
                     Some(Box::new(MutatedInfo {
                         vars: new_mutated.clone(),
-                        early_return_type: early_return_type_from_return_type(top_level_context, return_typ.0.clone()),
+                        early_return_type: early_return_type_from_return_type(
+                            top_level_context,
+                            return_typ.0.clone(),
+                        ),
 
                         stmt: mut_tuple,
                     })),
@@ -2499,6 +2539,7 @@ fn typecheck_statement(
             ))
         }
         Statement::ForLoop(x, e1, e2, (b, b_span)) => {
+            log::trace!("   Statement::ForLoop");
             let original_var_context = var_context;
             let (new_e1, t_e1, var_context) =
                 typecheck_expression(sess, e1, top_level_context, var_context)?;
@@ -2589,6 +2630,7 @@ fn typecheck_block(
     original_var_context: &VarContext,
     function_return_typ: &Spanned<BaseTyp>,
 ) -> TypecheckingResult<(Block, VarContext)> {
+    log::trace!("typecheck_block ({:?}, {:?})", b, b_span);
     let mut var_context = original_var_context.clone();
     let mut mutated_vars = VarSet(HashSet::new());
     let mut return_typ = Some((
@@ -2599,6 +2641,7 @@ fn typecheck_block(
     let n_stmts = b.stmts.len();
     for (i, s) in b.stmts.into_iter().enumerate() {
         let s_span = s.1.clone();
+        log::trace!("   s {:?}", s);
         let (new_stmt, stmt_typ, new_var_context, new_mutated_vars) = typecheck_statement(
             sess,
             s,
@@ -2648,7 +2691,10 @@ fn typecheck_block(
             stmts: new_stmts,
             mutated: Some(Box::new(MutatedInfo {
                 vars: mutated_vars,
-                early_return_type: early_return_type_from_return_type(top_level_context, function_return_typ.0.clone()),
+                early_return_type: early_return_type_from_return_type(
+                    top_level_context,
+                    function_return_typ.0.clone(),
+                ),
                 stmt: mut_tuple,
             })),
             return_typ,
@@ -2663,6 +2709,7 @@ fn typecheck_item(
     item: &DecoratedItem,
     top_level_context: &TopLevelContext,
 ) -> TypecheckingResult<DecoratedItem> {
+    log::trace!("typecheck_item ({:#?})", item);
     let i = &item.item;
     let i = match &i {
         Item::NaturalIntegerDecl(typ_ident, secrecy, canvas_size, info) => {
@@ -2698,6 +2745,7 @@ fn typecheck_item(
         }
         Item::AliasDecl(_, _) | Item::ImportedCrate(_) | Item::EnumDecl(_, _) => Ok(i.clone()),
         Item::FnDecl((f, f_span), sig, (b, b_span)) => {
+            log::trace!("   Item::FnDecl");
             let var_context = HashMap::new();
             let var_context = sig
                 .args


### PR DESCRIPTION
This allows us updating `im`.
I didn't update all `union` calls. But we probably should. Or maybe we should drop `im` and use the `std::collections` instead.

Also see https://github.com/bodil/im-rs/issues/202