### PR TITLE
pin concordium-base dependency to a50612e0

### DIFF
--- a/examples/bls12-381-hash/Cargo.toml
+++ b/examples/bls12-381-hash/Cargo.toml
@@ -24,6 +24,6 @@ pairing-plus = { git = "https://github.com/algorand/pairing-plus" } # published 
 sha2-08 = { package = "sha2", version = "0.8" }
 sha2-09 = { package = "sha2", version = "0.9" }
 bls12_381 = {version = "0.6.0", features = ["experimental"] }
-curve_arithmetic = { git = "https://github.com/Concordium/concordium-base" }
+curve_arithmetic = { git = "https://github.com/Concordium/concordium-base", rev = "a50612e023da79cb625cd36c52703af6ed483738" }
 pairing = "0.15"
 group = "0.2"


### PR DESCRIPTION
Newer versions of the repo use a relative git submodule that breaks our builds.