### PR TITLE
Make constants from other modules visible (fixes #272)

### DIFF
--- a/language/src/hir_to_rustspec.rs
+++ b/language/src/hir_to_rustspec.rs
@@ -412,17 +412,15 @@ fn process_fn_id(
         _ => {
             let def_path = tcx.def_path(*id);
             if def_path.krate == *krate_num {
-                if def_path.data.len() == 1 {
-                    let ty = translate_base_typ(tcx, &tcx.type_of(*id), &HashMap::new());
-                    match ty {
-                        Ok((ty, _)) => match def_path.data[0].data {
-                            DefPathData::ValueNs(name) => {
-                                extern_consts.insert(name.to_ident_string(), ty);
-                            }
-                            _ => (),
-                        },
-                        Err(_) => (),
-                    }
+                let ty = translate_base_typ(tcx, &tcx.type_of(*id), &HashMap::new());
+                match ty {
+                    Ok((ty, _)) => match def_path.data.last().unwrap().data {
+                        DefPathData::ValueNs(name) => {
+                            extern_consts.insert(name.to_ident_string(), ty);
+                        }
+                        _ => (),
+                    },
+                    Err(_) => (),
                 }
             }
         }
@@ -833,7 +831,7 @@ pub fn retrieve_external_data(
         let item_def_id = item.def_id.to_def_id();
 
         match &item.kind {
-            ItemKind::Fn(_, _, _) => process_fn_id(
+            ItemKind::Fn(_, _, _) | ItemKind::Const(_, _) => process_fn_id(
                 sess,
                 tcx,
                 &item_def_id,

--- a/language/test-crate/src/submod1/another_submod1_file.rs
+++ b/language/test-crate/src/submod1/another_submod1_file.rs
@@ -3,3 +3,7 @@ use crate::*;
 pub enum ResTyp {
     Ok(Res),
 }
+
+fn some_fun() -> u8 {
+    ERROR_VALUE
+}

--- a/language/test-crate/src/submod2/mod.rs
+++ b/language/test-crate/src/submod2/mod.rs
@@ -1,1 +1,3 @@
+pub const ERROR_VALUE: u8 = 0u8;
+
 pub type Res = (usize, usize);


### PR DESCRIPTION
Hi,

This PR should fix #272.
While looking for external symbols from a local module, the case `ItemKind::Const` was missed, and function `process_fn_id` was expecting paths of identifiers of length exactly one.