### PR TITLE
update examples/riot-runqueue

### DIFF
--- a/examples/riot-runqueue/Cargo.toml
+++ b/examples/riot-runqueue/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hacspec-lib = { path = "../../lib" }
+hacspec-lib = { path = "../../lib", default-features = false }

--- a/examples/riot-runqueue/src/lib.rs
+++ b/examples/riot-runqueue/src/lib.rs
@@ -6,9 +6,9 @@ const N_THREADS: usize = 30;
 const SENTINEL: u8 = 0xFFu8;
 
 #[derive(Clone, Copy, Debug)]
-pub struct RunqueueId(u8);
+pub struct RunqueueId(pub u8);
 #[derive(Clone, Copy, Debug)]
-pub struct ThreadId(u8);
+pub struct ThreadId(pub u8);
 
 public_bytes!(Tail, N_QUEUES);
 public_bytes!(NextIds, N_THREADS);

--- a/examples/riot-runqueue/src/lib.rs
+++ b/examples/riot-runqueue/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 use hacspec_lib::*;
 
 const U32_BITS: usize = 4 * 8;


### PR DESCRIPTION
This makes the riot-runqueue actually usable for RIOT. :)
I had that branch lying around for months, just rebased it now, let's see what CI says.