### PR TITLE
Allow question marks within expressions

### DIFF
--- a/fstar/Hacspec.Lib.fst
+++ b/fstar/Hacspec.Lib.fst
@@ -116,6 +116,8 @@ let bind_ok (#a #a' #b: Type) (v: result a b) (kont: a -> result a' b) : result 
    | Ok x -> kont x
    | Err y -> Err y
 
+let (let?) = bind_ok
+
 (*** Loops *)
 
 let rec foldi_

--- a/language/language-tests/question_mark.rs
+++ b/language/language-tests/question_mark.rs
@@ -62,7 +62,9 @@ pub fn fizzbarbuzz() -> Result<u32, U8> {
     for i in 0..200 {
         if true || false {
             let y = foo(true)?;
-            out = y as u32 + out;
+            out = y as u32
+		+ foo(Result::<bool, U8>::Ok(true)?)? as u32
+		+ out + Result::<u32, U8>::Ok(3u32)?;
             foo(false || true)?;
         } else {
             foo(false && true)?;
@@ -70,4 +72,16 @@ pub fn fizzbarbuzz() -> Result<u32, U8> {
         }
     }
     Result::<u32, U8>::Ok(out)
+}
+
+
+pub fn inline_question_marks() -> Result<u64, U8> {
+    let a = Result::<u64, U8>::Ok(100u64);
+    let b = Result::<u64, U8>::Ok(50u64);
+    let c = Result::<Result::<u64, U8>, U8>::Ok(Result::<u64, U8>::Ok(100u64));
+    let x = match c? {
+	Result::<u64, U8>::Ok(x) => if a? > 10u64 { 123u64 } else { b? + 3u64 },
+	Result::<u64, U8>::Err(x) => b? + 1u64 + a?,
+    };
+    Result::<u64, U8>::Ok(x)
 }

--- a/language/language-tests/question_mark.rs
+++ b/language/language-tests/question_mark.rs
@@ -63,8 +63,9 @@ pub fn fizzbarbuzz() -> Result<u32, U8> {
         if true || false {
             let y = foo(true)?;
             out = y as u32
-		+ foo(Result::<bool, U8>::Ok(true)?)? as u32
-		+ out + Result::<u32, U8>::Ok(3u32)?;
+                + foo(Result::<bool, U8>::Ok(true)?)? as u32
+                + out
+                + Result::<u32, U8>::Ok(3u32)?;
             foo(false || true)?;
         } else {
             foo(false && true)?;
@@ -74,14 +75,19 @@ pub fn fizzbarbuzz() -> Result<u32, U8> {
     Result::<u32, U8>::Ok(out)
 }
 
-
 pub fn inline_question_marks() -> Result<u64, U8> {
     let a = Result::<u64, U8>::Ok(100u64);
     let b = Result::<u64, U8>::Ok(50u64);
-    let c = Result::<Result::<u64, U8>, U8>::Ok(Result::<u64, U8>::Ok(100u64));
+    let c = Result::<Result<u64, U8>, U8>::Ok(Result::<u64, U8>::Ok(100u64));
     let x = match c? {
-	Result::<u64, U8>::Ok(x) => if a? > 10u64 { 123u64 } else { b? + 3u64 },
-	Result::<u64, U8>::Err(x) => b? + 1u64 + a?,
+        Result::<u64, U8>::Ok(x) => {
+            if a? > 10u64 {
+                123u64
+            } else {
+                b? + 3u64
+            }
+        }
+        Result::<u64, U8>::Err(x) => b? + 1u64 + a?,
     };
     Result::<u64, U8>::Ok(x)
 }

--- a/language/src/ast_to_rustspec.rs
+++ b/language/src/ast_to_rustspec.rs
@@ -1542,12 +1542,18 @@ fn translate_expr(
             Err(())
         }
         ExprKind::Paren(e1) => translate_expr(sess, specials, e1),
-        ExprKind::Try(_) => {
-            sess.span_rustspec_err(
-                e.span.clone(),
-                "question marks inside expressions are not allowed in Hacspec",
+        ExprKind::Try(e1) => {
+            let e1 = Expression::QuestionMark(
+                Box::new(match translate_expr(sess, specials, e1)? {
+                    (ExprTranslationResult::TransExpr(e), es) => (e, es),
+                    _ => Err(sess.span_rustspec_err(
+                        e1.span,
+                        "question marks on statements are not allowed in Hacspec",
+                    ))?,
+                }),
+                None,
             );
-            Err(())
+            Ok((ExprTranslationResult::TransExpr(e1), e.span.clone().into()))
         }
         ExprKind::Err => {
             sess.span_rustspec_err(e.span, "error expressions are not allowed in Hacspec");

--- a/language/src/elab_monadic_lets.rs
+++ b/language/src/elab_monadic_lets.rs
@@ -1,5 +1,4 @@
 use crate::rustspec::*;
-// use crate::ast_mapper::*;
 use rustc_span::DUMMY_SP;
 
 static ID_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
@@ -77,7 +76,7 @@ pub fn eliminate_question_marks_in_expressions(e: &Expression) -> Expression {
             let e1 = eliminate_question_marks_in_spanned_expressions(&e1);
             let mv = fresh_var();
             let mv_expr = Box::new((Expression::Named(mv.clone()), DUMMY_SP.into()));
-            if let (Expression::MonadicLet(carrier, bindings, body, pure), _) = e1 {
+            if let (Expression::MonadicLet(carrier, bindings, body, _), _) = e1 {
                 Expression::MonadicLet(
                     carrier,
                     bindings

--- a/language/src/elab_monadic_lets.rs
+++ b/language/src/elab_monadic_lets.rs
@@ -1,0 +1,215 @@
+use crate::rustspec::*;
+// use crate::ast_mapper::*;
+use rustc_span::DUMMY_SP;
+
+static ID_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+fn fresh_var() -> Ident {
+    let id = ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    Ident::Local(LocalIdent {
+        name: "mvar".to_string(),
+        id: id,
+    })
+}
+
+/// Wraps an [expression][Expression] `exp` with a `pure` monadic
+/// operation from monad `carrier`.
+fn pure(carrier: CarrierTyp, exp: Expression) -> Expression {
+    Expression::MonadicLet(carrier, vec![], Box::new((exp, DUMMY_SP.into())), true)
+}
+
+/// Wrap `exp` into a `pure` (see function [pure][pure]), but only if
+/// `exp` is not a `pure …` already.
+fn pure_if_non_monadic(carrier: CarrierTyp, x: Spanned<Expression>) -> Spanned<Expression> {
+    match x.0 {
+        Expression::MonadicLet(..) => x,
+        _ => (pure(carrier, x.0), x.1),
+    }
+}
+
+/// Rewrites an spanned expression to elminate
+/// `Expression::QuestionMark` nodes, introducting
+/// `Expression::MonadicLet`.
+pub fn eliminate_question_marks_in_expressions(e: &Expression) -> Expression {
+    // Whenever a sub-expression is monadic, we push it into the
+    // mutable `bindings`. Since monadic nodes
+    // [MonadicLet][Expression::MonadicLet] only reflect question
+    // marks, we can only be in presence of *one* monad per function.
+    let mut bindings: Option<(CarrierTyp, Vec<_>)> = None;
+    let mut wrap_pure_node = true;
+    let mut elim_sub_expr0 =
+        |arg: Expression| match eliminate_question_marks_in_expressions(&arg.clone()).clone() {
+            Expression::MonadicLet(carrier, lbs, body, _) => {
+                bindings = Some(match bindings.clone() {
+                    None => (carrier, lbs.clone()),
+                    Some((carrier, prev_lbs)) => (
+                        carrier,
+                        prev_lbs.iter().chain(lbs.iter()).cloned().collect(),
+                    ),
+                });
+                body.0
+            }
+            arg => arg,
+        };
+    let mut elim_sub_expr = |arg: Spanned<Expression>| (elim_sub_expr0(arg.clone().0), arg.1);
+    let mut elim_boxed_sub_expr =
+        |arg: &Box<Spanned<Expression>>| Box::new(elim_sub_expr(*arg.clone()));
+    fn find_monadic_let_carrier<T>(exprs: T) -> Option<CarrierTyp>
+    where
+        T: Iterator<Item = Expression> + Clone,
+    {
+        exprs.clone().find_map(|e| match e {
+            Expression::MonadicLet(carrier, ..) => Some(carrier),
+            _ => None,
+        })
+    }
+    let e = match e {
+        Expression::MonadicLet(..) => panic!("Typed ADT should never contains a [MonadicLet] node"),
+        Expression::Unary(op, e1, t) => {
+            Expression::Unary(op.clone(), elim_boxed_sub_expr(e1), t.clone())
+        }
+        Expression::Binary(op, e1, e2, t) => Expression::Binary(
+            op.clone(),
+            elim_boxed_sub_expr(e1),
+            elim_boxed_sub_expr(e2),
+            t.clone(),
+        ),
+        Expression::QuestionMark(e1, typ) => {
+            let e1 = eliminate_question_marks_in_spanned_expressions(&e1);
+            let mv = fresh_var();
+            let mv_expr = Box::new((Expression::Named(mv.clone()), DUMMY_SP.into()));
+            if let (Expression::MonadicLet(carrier, bindings, body, pure), _) = e1 {
+                Expression::MonadicLet(
+                    carrier,
+                    bindings
+                        .into_iter()
+                        .chain(std::iter::once((mv.clone(), body.clone())))
+                        .collect(),
+                    mv_expr,
+                    false,
+                )
+            } else {
+                Expression::MonadicLet(
+                    typ.clone()
+                        .expect("[QuestionMark] nodes in typed ADTs should always carry a type"),
+                    vec![(mv.clone(), Box::new(e1))],
+                    mv_expr,
+                    true,
+                )
+            }
+        }
+        Expression::FuncCall(prefix, name, args, arg_types) => Expression::FuncCall(
+            prefix.clone(),
+            name.clone(),
+            args.into_iter()
+                .cloned()
+                .map(|(x, xb)| (elim_sub_expr(x), xb))
+                .collect(),
+            arg_types.clone(),
+        ),
+        Expression::MethodCall(self_, self_typ, name, args, arg_types) => {
+            let (self_expr, self_span) = *self_.clone();
+            Expression::MethodCall(
+                Box::new((elim_sub_expr(self_expr), self_span)),
+                self_typ.clone(),
+                name.clone(),
+                args.into_iter()
+                    .cloned()
+                    .map(|(x, xb)| (elim_sub_expr(x), xb))
+                    .collect(),
+                arg_types.clone(),
+            )
+        }
+        Expression::EnumInject(t, n, e1) => Expression::EnumInject(
+            t.clone(),
+            n.clone(),
+            e1.as_ref()
+                // TODO: Why does EnumInject carries a
+                // `Spanned<Box<Expression>>` instead of a
+                // `Box<Spanned<Expression>>`?
+                .map(|(e, es)| (*e.clone(), es.clone()))
+                .map(|e1| elim_sub_expr(e1.clone()))
+                .map(|(e, es)| (Box::new(e), es)),
+        ),
+        Expression::InlineConditional(scrutinee, then_, else_) => {
+            let scrutinee = elim_boxed_sub_expr(scrutinee);
+            let then_ = eliminate_question_marks_in_spanned_expressions(&*then_.clone());
+            let else_ = eliminate_question_marks_in_spanned_expressions(&*else_.clone());
+            if let Some(carrier) =
+                find_monadic_let_carrier([then_.clone().0, else_.clone().0].iter().cloned())
+            {
+                wrap_pure_node = false;
+                Expression::InlineConditional(
+                    scrutinee,
+                    Box::new(pure_if_non_monadic(carrier.clone(), then_)),
+                    Box::new(pure_if_non_monadic(carrier.clone(), else_)),
+                )
+            } else {
+                Expression::InlineConditional(scrutinee, Box::new(then_), Box::new(else_))
+            }
+        }
+        Expression::MatchWith(scrutinee, branches) => {
+            let branches = branches.into_iter().cloned().map(|(t, cn, p, arm)| {
+                (
+                    t,
+                    cn,
+                    p,
+                    eliminate_question_marks_in_spanned_expressions(&arm),
+                )
+            });
+            let scrutinee = elim_boxed_sub_expr(scrutinee);
+            if let Some(carrier) = find_monadic_let_carrier(branches.clone().map(|(.., (x, _))| x))
+            {
+                wrap_pure_node = false;
+                let def = Box::new((
+                    Expression::MatchWith(
+                        scrutinee,
+                        branches
+                            .map(|(t, cn, p, arm)| {
+                                (t, cn, p, pure_if_non_monadic(carrier.clone(), arm))
+                            })
+                            .collect(),
+                    ),
+                    DUMMY_SP.into(),
+                ));
+                let mv = fresh_var();
+                Expression::MonadicLet(
+                    carrier.clone(),
+                    vec![(mv.clone(), def)],
+                    Box::new((Expression::Named(mv.clone()), DUMMY_SP.into())),
+                    true,
+                )
+            } else {
+                Expression::MatchWith(scrutinee, branches.collect())
+            }
+        }
+        Expression::ArrayIndex(n, e1, t) => {
+            Expression::ArrayIndex(n.clone(), elim_boxed_sub_expr(e1), t.clone())
+        }
+        Expression::NewArray(n, t, args) => Expression::NewArray(
+            n.clone(),
+            t.clone(),
+            args.into_iter().cloned().map(elim_sub_expr).collect(),
+        ),
+        Expression::Tuple(args) => {
+            Expression::Tuple(args.into_iter().cloned().map(elim_sub_expr).collect())
+        }
+        Expression::IntegerCasting(e1, d, o) => {
+            Expression::IntegerCasting(elim_boxed_sub_expr(e1), d.clone(), o.clone())
+        }
+        Expression::Named(_) | Expression::Lit(_) => e.clone(),
+    };
+    match bindings {
+        Some((carrier, bindings)) => Expression::MonadicLet(
+            carrier,
+            bindings.clone(),
+            Box::new((e, DUMMY_SP.into())),
+            wrap_pure_node,
+        ),
+        _ => e,
+    }
+}
+pub fn eliminate_question_marks_in_spanned_expressions(
+    e: &Spanned<Expression>,
+) -> Spanned<Expression> {
+    (eliminate_question_marks_in_expressions(&e.0), e.1.clone())
+}

--- a/language/src/main.rs
+++ b/language/src/main.rs
@@ -13,6 +13,7 @@ extern crate rustc_session;
 extern crate rustc_span;
 
 mod ast_to_rustspec;
+mod elab_monadic_lets;
 mod hir_to_rustspec;
 mod name_resolution;
 mod rustspec;

--- a/language/src/name_resolution.rs
+++ b/language/src/name_resolution.rs
@@ -158,7 +158,7 @@ fn resolve_expression(
             ))
         }
         Expression::MonadicLet(..) =>
-        // TODO GADT: implement some kind of GADT to eliminate MonadicLet via typing information
+        // TODO: eliminiate this `panic!` with nicer types (See issue #303)
         {
             panic!(
                 "The name resolution phase expects an AST free of [Expression::MonadicLet] node."

--- a/language/src/name_resolution.rs
+++ b/language/src/name_resolution.rs
@@ -157,6 +157,20 @@ fn resolve_expression(
                 e_span,
             ))
         }
+        Expression::MonadicLet(..) =>
+        // TODO GADT: implement some kind of GADT to eliminate MonadicLet via typing information
+        {
+            panic!(
+                "The name resolution phase expects an AST free of [Expression::MonadicLet] node."
+            )
+        }
+        Expression::QuestionMark(e, typ) => Ok((
+            Expression::QuestionMark(
+                Box::new(resolve_expression(sess, *e, name_context, top_level_ctx)?),
+                typ.clone(),
+            ),
+            e_span,
+        )),
         Expression::MatchWith(arg, arms) => {
             let new_arg = resolve_expression(sess, *arg, name_context, top_level_ctx)?;
             let new_arms = check_vec(
@@ -174,7 +188,8 @@ fn resolve_expression(
                         for (k, v) in new_name_context.into_iter() {
                             updated_name_context = updated_name_context.update(k, v);
                         }
-                        let new_arm = resolve_expression(sess, arm, &updated_name_context, top_level_ctx)?;
+                        let new_arm =
+                            resolve_expression(sess, arm, &updated_name_context, top_level_ctx)?;
                         Ok((enum_name, case_name, new_payload, new_arm))
                     })
                     .collect(),
@@ -309,7 +324,8 @@ fn resolve_pattern(
                     .iter()
                     .fold(Ok((Vec::new(), HashMap::new())), |acc, pat_arg| {
                         let (mut acc_pat, acc_name) = acc?;
-                        let (new_pat, mut sub_name_context) = resolve_pattern(sess, pat_arg, top_ctx)?;
+                        let (new_pat, mut sub_name_context) =
+                            resolve_pattern(sess, pat_arg, top_ctx)?;
                         acc_pat.push((new_pat, pat_arg.1.clone()));
                         for (k, v) in acc_name.into_iter() {
                             sub_name_context = sub_name_context.update(k, v);

--- a/language/src/rustspec.rs
+++ b/language/src/rustspec.rs
@@ -315,7 +315,7 @@ pub enum BinOpKind {
     Gt,
 }
 
-/// Enumaration of the types allowed as question marks's monad
+/// Enumeration of the types allowed as question marks's monad
 /// representation. Named after the [Carrier][std::ops::Carrier]
 /// trait.
 #[derive(Clone, PartialEq, Eq, Debug, Serialize)]
@@ -363,7 +363,7 @@ pub enum Expression {
     ///    xₙ <- eₙ
     ///    return $ f x₀ … xₙ
     /// ```
-    /// Note the boolean flag indiquates wether we shall insert a `pure` monadic operation or not (that is, above, shall we have `return $ f x₀ … xₙ` or simply `f x₀ … xₙ`).
+    /// Note the boolean flag indicates whether we shall insert a `pure` monadic operation or not (that is, above, shall we have `return $ f x₀ … xₙ` or simply `f x₀ … xₙ`).
     /// This node appears only after the [question marks elimination][desugar::eliminate_question_marks_in_expressions] phase.
     MonadicLet(
         CarrierTyp,                             // Are we dealing with `Result` or `Option`?
@@ -427,7 +427,7 @@ pub enum Pattern {
     SingleCaseEnum(Spanned<TopLevelIdent>, Box<Spanned<Pattern>>),
 }
 
-#[derive(Clone, Serialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Debug, PartialEq, Eq)]
 pub enum EarlyReturnType {
     Option,
     Result,

--- a/language/src/rustspec.rs
+++ b/language/src/rustspec.rs
@@ -352,6 +352,25 @@ pub enum Expression {
         Box<Spanned<Expression>>,
         Box<Spanned<Expression>>,
     ),
+    QuestionMark(
+        Box<Spanned<Expression>>,
+        Fillable<CarrierTyp>, // Filled by typechecking phase
+    ),
+    /// One or multiple monadic bindings. For instance, `MonadicLet(M, [(x₀, e₀), …, (xₙ, eₙ)], «f x₀ … xₙ», true)` represents:
+    /// ```haskell
+    /// do x₀ <- e₀
+    ///    …
+    ///    xₙ <- eₙ
+    ///    return $ f x₀ … xₙ
+    /// ```
+    /// Note the boolean flag indiquates wether we shall insert a `pure` monadic operation or not (that is, above, shall we have `return $ f x₀ … xₙ` or simply `f x₀ … xₙ`).
+    /// This node appears only after the [question marks elimination][desugar::eliminate_question_marks_in_expressions] phase.
+    MonadicLet(
+        CarrierTyp,                             // Are we dealing with `Result` or `Option`?
+        Vec<(Ident, Box<Spanned<Expression>>)>, // List of "monadic" bindings
+        Box<Spanned<Expression>>,               // body
+        bool, // should we insert a `pure` node? (`pure` being e.g. `Ok`)
+    ),
     Named(Ident),
     // FuncCall(prefix, name, args)
     FuncCall(

--- a/language/src/rustspec.rs
+++ b/language/src/rustspec.rs
@@ -2,10 +2,10 @@ use core::cmp::PartialEq;
 use core::hash::Hash;
 use im::HashSet;
 use itertools::Itertools;
-use rustc_span::{Span};
+use rustc_errors::MultiSpan;
+use rustc_span::Span;
 use serde::{ser::SerializeSeq, Serialize, Serializer};
 use std::fmt;
-use rustc_errors::MultiSpan;
 
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug, Copy)]
 pub struct RustspecSpan(pub Span);
@@ -315,6 +315,29 @@ pub enum BinOpKind {
     Gt,
 }
 
+/// Enumaration of the types allowed as question marks's monad
+/// representation. Named after the [Carrier][std::ops::Carrier]
+/// trait.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize)]
+pub enum CarrierTyp {
+    Result(Spanned<BaseTyp>, Spanned<BaseTyp>),
+    Option(Spanned<BaseTyp>),
+}
+
+/// Extracts the payload type of a carrier type, i.e., `A` is the
+/// payload type of `Either<A, B>`.
+pub fn carrier_payload(carrier: CarrierTyp) -> Spanned<BaseTyp> {
+    match carrier {
+        CarrierTyp::Result(ok, ..) | CarrierTyp::Option(ok, ..) => ok,
+    }
+}
+pub fn carrier_kind(carrier: CarrierTyp) -> EarlyReturnType {
+    match carrier {
+        CarrierTyp::Result(..) => EarlyReturnType::Result,
+        CarrierTyp::Option(..) => EarlyReturnType::Option,
+    }
+}
+
 #[derive(Clone, Serialize, Debug)]
 pub enum Expression {
     Unary(UnOpKind, Box<Spanned<Expression>>, Option<Typ>),
@@ -385,7 +408,7 @@ pub enum Pattern {
     SingleCaseEnum(Spanned<TopLevelIdent>, Box<Spanned<Pattern>>),
 }
 
-#[derive(Clone, Serialize, Debug)]
+#[derive(Clone, Serialize, Debug, PartialEq)]
 pub enum EarlyReturnType {
     Option,
     Result,

--- a/language/src/rustspec_to_coq.rs
+++ b/language/src/rustspec_to_coq.rs
@@ -792,6 +792,7 @@ fn translate_expression<'a>(e: Expression, top_ctx: &'a TopLevelContext) -> RcDo
     match e {
         Expression::MonadicLet(..) => panic!("TODO: Coq support for Expression::MonadicLet"),
         Expression::QuestionMark(..) => {
+            // TODO: eliminiate this `panic!` with nicer types (See issue #303)
             panic!("[Expression::QuestionMark] nodes should have been eliminated before printing.")
         }
         Expression::Binary((op, _), e1, e2, op_typ) => {

--- a/language/src/rustspec_to_coq.rs
+++ b/language/src/rustspec_to_coq.rs
@@ -790,6 +790,10 @@ fn translate_func_name<'a>(
 
 fn translate_expression<'a>(e: Expression, top_ctx: &'a TopLevelContext) -> RcDoc<'a, ()> {
     match e {
+        Expression::MonadicLet(..) => panic!("TODO: Coq support for Expression::MonadicLet"),
+        Expression::QuestionMark(..) => {
+            panic!("[Expression::QuestionMark] nodes should have been eliminated before printing.")
+        }
         Expression::Binary((op, _), e1, e2, op_typ) => {
             let e1 = e1.0;
             let e2 = e2.0;

--- a/language/src/rustspec_to_easycrypt.rs
+++ b/language/src/rustspec_to_easycrypt.rs
@@ -669,6 +669,10 @@ fn translate_func_name<'a>(
 
 fn translate_expression<'a>(e: Expression, top_ctx: &'a TopLevelContext) -> RcDoc<'a, ()> {
     match e {
+        Expression::MonadicLet(..) => panic!("TODO: Easycrypt support for Expression::MonadicLet"),
+        Expression::QuestionMark(..) => {
+            panic!("[Expression::QuestionMark] nodes should have been eliminated before printing.")
+        }
         Expression::Binary((op, _), e1, e2, op_typ) => {
             let e1 = e1.0;
             let e2 = e2.0;

--- a/language/src/rustspec_to_easycrypt.rs
+++ b/language/src/rustspec_to_easycrypt.rs
@@ -671,6 +671,7 @@ fn translate_expression<'a>(e: Expression, top_ctx: &'a TopLevelContext) -> RcDo
     match e {
         Expression::MonadicLet(..) => panic!("TODO: Easycrypt support for Expression::MonadicLet"),
         Expression::QuestionMark(..) => {
+	    // TODO: eliminiate this `panic!` with nicer types (See issue #303)
             panic!("[Expression::QuestionMark] nodes should have been eliminated before printing.")
         }
         Expression::Binary((op, _), e1, e2, op_typ) => {

--- a/language/src/rustspec_to_fstar.rs
+++ b/language/src/rustspec_to_fstar.rs
@@ -793,6 +793,12 @@ fn translate_expression<'a>(
     top_ctx: &'a TopLevelContext,
 ) -> RcDoc<'a, ()> {
     match e {
+        Expression::MonadicLet(carrier, bindings, body, wrap_return) => {
+            panic!("[Expression::MonadicLet] TODO F* support.")
+        }
+        Expression::QuestionMark(..) => {
+            panic!("[Expression::QuestionMark] nodes should have been eliminated before printing.")
+        }
         Expression::Binary(op, e1, e2, op_typ) => {
             let e1 = e1.0;
             let e2 = e2.0;

--- a/language/src/rustspec_to_fstar.rs
+++ b/language/src/rustspec_to_fstar.rs
@@ -838,6 +838,7 @@ fn translate_expression<'a>(
             top_ctx,
         )),
         Expression::QuestionMark(..) => {
+            // TODO: eliminiate this `panic!` with nicer types (See issue #303)
             panic!("[Expression::QuestionMark] nodes should have been eliminated before printing.")
         }
         Expression::Binary(op, e1, e2, op_typ) => {

--- a/language/src/rustspec_to_fstar.rs
+++ b/language/src/rustspec_to_fstar.rs
@@ -39,7 +39,9 @@ fn make_error_returning_let_binding<'a, F: FnOnce() -> RcDoc<'a, ()>>(
     expr: RcDoc<'a, ()>,
     kont: F,
 ) -> RcDoc<'a, ()> {
-    RcDoc::as_string("match")
+    RcDoc::as_string("begin")
+        .append(RcDoc::space())
+        .append(RcDoc::as_string("match"))
         .append(RcDoc::space())
         .append(make_paren(expr.group()))
         .append(RcDoc::space())
@@ -50,7 +52,7 @@ fn make_error_returning_let_binding<'a, F: FnOnce() -> RcDoc<'a, ()>>(
         .append(
             RcDoc::as_string("| Ok ")
                 .append(RcDoc::space())
-                .append(
+                .append(make_paren(
                     pat.append(match typ {
                         None => RcDoc::nil(),
                         Some(tau) => RcDoc::space()
@@ -59,13 +61,22 @@ fn make_error_returning_let_binding<'a, F: FnOnce() -> RcDoc<'a, ()>>(
                             .append(tau),
                     })
                     .group(),
-                )
+                ))
                 .append(RcDoc::space())
                 .append(RcDoc::as_string("->"))
                 .group()
                 .append(RcDoc::line().append(kont()))
                 .nest(2),
         )
+        .append(RcDoc::space())
+        .append(RcDoc::as_string("end"))
+}
+
+pub fn carrier_operator(carrier: EarlyReturnType) -> String {
+    match carrier {
+        EarlyReturnType::Result => "?".to_string(),
+        EarlyReturnType::Option => "*".to_string(),
+    }
 }
 
 fn make_let_binding<'a>(
@@ -73,8 +84,15 @@ fn make_let_binding<'a>(
     typ: Option<RcDoc<'a, ()>>,
     expr: RcDoc<'a, ()>,
     toplevel: bool,
+    monadic: Option<EarlyReturnType>,
 ) -> RcDoc<'a, ()> {
     RcDoc::as_string("let")
+        .append(
+            monadic
+                .map(carrier_operator)
+                .map(RcDoc::as_string)
+                .unwrap_or(RcDoc::nil()),
+        )
         .append(RcDoc::space())
         .append(
             pat.append(match typ {
@@ -793,9 +811,32 @@ fn translate_expression<'a>(
     top_ctx: &'a TopLevelContext,
 ) -> RcDoc<'a, ()> {
     match e {
-        Expression::MonadicLet(carrier, bindings, body, wrap_return) => {
-            panic!("[Expression::MonadicLet] TODO F* support.")
-        }
+        Expression::MonadicLet(carrier, bindings, body, wrap_return) => RcDoc::intersperse(
+            bindings.into_iter().map(|(id, def)| {
+                RcDoc::as_string("let?")
+                    .append(RcDoc::space())
+                    .append(translate_ident(id.clone()))
+                    .append(RcDoc::space())
+                    .append(RcDoc::as_string("="))
+                    .append(RcDoc::space())
+                    .append(translate_expression(sess, (*def).0, top_ctx))
+                    .append(RcDoc::space())
+                    .append(RcDoc::as_string("in"))
+                    .append(RcDoc::space())
+                    .group()
+            }),
+            RcDoc::line(),
+        )
+        .append(translate_expression(
+            sess,
+            (if wrap_return {
+                crate::typechecker::pure_carrier(carrier, *body.clone())
+            } else {
+                *body.clone()
+            })
+            .0,
+            top_ctx,
+        )),
         Expression::QuestionMark(..) => {
             panic!("[Expression::QuestionMark] nodes should have been eliminated before printing.")
         }
@@ -809,7 +850,9 @@ fn translate_expression<'a>(
                 .append(make_paren(translate_expression(sess, e2, top_ctx)))
                 .group()
         }
-        Expression::MatchWith(arg, arms) => RcDoc::as_string("match")
+        Expression::MatchWith(arg, arms) => RcDoc::as_string("begin")
+            .append(RcDoc::space())
+            .append(RcDoc::as_string("match"))
             .append(RcDoc::space())
             .append(translate_expression(sess, arg.0, top_ctx))
             .append(RcDoc::space())
@@ -835,7 +878,9 @@ fn translate_expression<'a>(
                         .append(translate_expression(sess, e1.0, top_ctx))
                 }),
                 RcDoc::line(),
-            )),
+            ))
+            .append(RcDoc::space())
+            .append("end"),
         Expression::EnumInject(enum_name, case_name, payload) => {
             translate_enum_case_name(enum_name.clone(), case_name.0.clone()).append(match payload {
                 None => RcDoc::nil(),
@@ -948,6 +993,7 @@ fn translate_expression<'a>(
                                 .map(|(e, _)| translate_expression(sess, e, top_ctx)),
                         ),
                         false,
+                        None,
                     )
                     .append(RcDoc::space())
                     .append(
@@ -1103,8 +1149,28 @@ fn translate_statements<'a>(
         None => return RcDoc::nil(),
         Some(s) => s.clone(),
     };
+    // let s0 = match s.0 {
+    // 	Statement::LetBinding((pat, _), typ, (Expression::MonadicLet(_, _), _), false) => {
+    // 	    panic!()
+    // 	},
+    // 	_ => s.0
+    // };
     match s.0 {
+        // Statement::LetBinding(pat, typ, (Expression::MonadicLet(lbs, body), span), false) => {
+        //     // translate_statements(
+        //     // 	lbs.into_iter(
+        //     // 	    |(id, def)| Statement::LetBinding()
+        //     // 	).chain(std::iter::once(
+        //     // 	    (Statement::LetBinding(pat.clone(), typ.clone(), body, false), s.1)
+        //     // 	))
+        //     // )
+        // }
         Statement::LetBinding((pat, _), typ, (expr, _), question_mark) => {
+            let question_mark = question_mark;
+            // || (match expr {
+            // 	Expression::MonadicLet(..) => true,
+            // 	_ => false
+            // });
             if question_mark {
                 make_error_returning_let_binding(
                     translate_pattern(pat.clone()),
@@ -1118,6 +1184,11 @@ fn translate_statements<'a>(
                     typ.map(|(typ, _)| translate_typ(typ)),
                     translate_expression(sess, expr.clone(), top_ctx),
                     false,
+                    if question_mark {
+                        Some(EarlyReturnType::Result)
+                    } else {
+                        None
+                    },
                 )
                 .append(RcDoc::hardline())
                 .append(translate_statements(sess, statements, top_ctx))
@@ -1137,6 +1208,11 @@ fn translate_statements<'a>(
                     None,
                     translate_expression(sess, e1.clone(), top_ctx),
                     false,
+                    if question_mark {
+                        Some(EarlyReturnType::Result)
+                    } else {
+                        None
+                    },
                 )
                 .append(RcDoc::hardline())
                 .append(translate_statements(sess, statements, top_ctx))
@@ -1162,9 +1238,15 @@ fn translate_statements<'a>(
                     None,
                     translate_expression(sess, e2.clone(), top_ctx),
                     || {
-                        make_let_binding(translate_ident(x.clone()), None, array_upd_payload, false)
-                            .append(RcDoc::hardline())
-                            .append(translate_statements(sess, statements, top_ctx))
+                        make_let_binding(
+                            translate_ident(x.clone()),
+                            None,
+                            array_upd_payload,
+                            false,
+                            None,
+                        )
+                        .append(RcDoc::hardline())
+                        .append(translate_statements(sess, statements, top_ctx))
                     },
                 )
             } else {
@@ -1176,9 +1258,15 @@ fn translate_statements<'a>(
                     .append(make_paren(translate_expression(sess, e1.clone(), top_ctx)))
                     .append(RcDoc::space())
                     .append(make_paren(translate_expression(sess, e2.clone(), top_ctx)));
-                make_let_binding(translate_ident(x.clone()), None, array_upd_payload, false)
-                    .append(RcDoc::hardline())
-                    .append(translate_statements(sess, statements, top_ctx))
+                make_let_binding(
+                    translate_ident(x.clone()),
+                    None,
+                    array_upd_payload,
+                    false,
+                    None,
+                )
+                .append(RcDoc::hardline())
+                .append(translate_statements(sess, statements, top_ctx))
             }
         }
         Statement::ReturnExp(e1) => translate_expression(sess, e1.clone(), top_ctx),
@@ -1238,7 +1326,7 @@ fn translate_statements<'a>(
                     translate_statements(sess, statements, top_ctx)
                 })
             } else {
-                make_let_binding(pat, None, expr, false)
+                make_let_binding(pat, None, expr, false, None)
                     .append(RcDoc::hardline())
                     .append(translate_statements(sess, statements, top_ctx))
             }
@@ -1289,7 +1377,7 @@ fn translate_statements<'a>(
                     translate_statements(sess, statements, top_ctx)
                 })
             } else {
-                make_let_binding(mut_tuple, None, loop_expr, false)
+                make_let_binding(mut_tuple, None, loop_expr, false, None)
                     .append(RcDoc::hardline())
                     .append(translate_statements(sess, statements, top_ctx))
             }
@@ -1359,6 +1447,7 @@ fn translate_item<'a>(
                 })
                 .group(),
             true,
+            None,
         ),
         Item::EnumDecl(name, cases) => RcDoc::as_string("noeq type")
             .append(RcDoc::space())
@@ -1422,6 +1511,7 @@ fn translate_item<'a>(
                                     make_paren(translate_expression(sess, size.0.clone(), top_ctx)),
                                 ),
                                 true,
+                                None,
                             ))
                     }
                 })
@@ -1431,6 +1521,7 @@ fn translate_item<'a>(
             Some(translate_base_typ(ty.0.clone())),
             translate_expression(sess, e.0.clone(), top_ctx),
             true,
+            None,
         ),
         Item::NaturalIntegerDecl(nat_name, _secrecy, canvas_size, info) => {
             let canvas_size = match &canvas_size.0 {

--- a/language/src/typechecker.rs
+++ b/language/src/typechecker.rs
@@ -2211,7 +2211,7 @@ fn typecheck_question_mark(
     expr_span: RustspecSpan,
     top_level_context: &TopLevelContext,
 ) -> TypecheckingResult<Typ> {
-    let mut expr_typ = (
+    let expr_typ = (
         expr_typ.0,
         (
             dealias_type(expr_typ.1 .0, top_level_context),
@@ -2223,121 +2223,55 @@ fn typecheck_question_mark(
         return_typ.1.clone(),
     );
     if question_mark {
-        match expr_typ {
-            (
-                (Borrowing::Consumed, _),
-                (BaseTyp::Named((TopLevelIdent { string: name, .. }, _), Some(args)), _),
-            ) if name == "Option" && args.len() == 1 => {
-                let some_typ = &args[0];
-                match return_typ {
-                    (
-                        BaseTyp::Named(
-                            (
-                                TopLevelIdent {
-                                    string: return_name,
-                                    ..
-                                },
-                                _,
-                            ),
-                            Some(return_args),
-                        ),
-                        _,
-                    ) if return_name == "Option" && return_args.len() == 1 => {
-                        expr_typ = ((Borrowing::Consumed, some_typ.1.clone()), some_typ.clone());
-                    }
-                    _ => {
-                        sess.span_rustspec_err(
-                            return_typ.1,
-                            format!(
-                                "expected a option type for this \
-                    return type because of a question mark in the function, got {}",
-                                return_typ.0,
-                            )
-                            .as_str(),
-                        );
-                        return Err(());
-                    }
-                }
-            }
-            (
-                (Borrowing::Consumed, _),
-                (BaseTyp::Named((TopLevelIdent { string: name, .. }, _), Some(args)), _),
-            ) if name == "Result" && args.len() == 2 => {
-                let ok_typ = &args[0];
-                let err_typ = &args[1];
-                match return_typ {
-                    (
-                        BaseTyp::Named(
-                            (
-                                TopLevelIdent {
-                                    string: return_name,
-                                    ..
-                                },
-                                _,
-                            ),
-                            Some(return_args),
-                        ),
-                        _,
-                    ) if return_name == "Result" && return_args.len() == 2 => {
-                        let err_typ_ret = &args[1];
-                        match unify_types(
-                            sess,
-                            &((Borrowing::Consumed, err_typ.1.clone()), err_typ.clone()),
-                            &(
-                                (Borrowing::Consumed, err_typ_ret.1.clone()),
-                                err_typ_ret.clone(),
-                            ),
-                            &HashMap::new(),
-                            top_level_context,
-                        )? {
-                            Some(_) => {
-                                expr_typ =
-                                    ((Borrowing::Consumed, ok_typ.1.clone()), ok_typ.clone());
-                            }
-                            None => {
-                                sess.span_rustspec_err(
-                                    expr_span,
-                                    format!(
-                                        "the type returned in case of error by this \
-                                        expression is {}, expected {}",
-                                        err_typ.0, err_typ_ret.0,
-                                    )
-                                    .as_str(),
-                                );
-                                return Err(());
-                            }
-                        }
-                    }
-                    _ => {
-                        sess.span_rustspec_err(
-                            return_typ.1,
-                            format!(
-                                "expected a result type for this \
-                    return type because of a question mark in the function, got {}",
-                                return_typ.0,
-                            )
-                            .as_str(),
-                        );
-                        return Err(());
-                    }
-                }
-            }
-            _ => {
+        let expr_carrier: Result<CarrierTyp, _> = match expr_typ.clone() {
+            ((Borrowing::Consumed, _), (expr_typ, _)) => expr_typ.try_into(),
+            _ => Err(()),
+        };
+        let return_carrier: Result<CarrierTyp, _> = return_typ.0.clone().try_into();
+
+        match (expr_carrier, return_carrier) {
+            (Err(..), _) => {
                 sess.span_rustspec_err(
                     expr_span,
                     format!(
                         "expected a result type for this \
-            expression ending with a question mark, got {}{}",
+			 expression ending with a question mark, got {}{}",
                         (expr_typ.0).0,
                         (expr_typ.1).0
                     )
                     .as_str(),
                 );
-                return Err(());
+                Err(())
+            }
+            (Ok(expr_carrier), Ok(return_carrier))
+                if carrier_kind(expr_carrier.clone()) == carrier_kind(return_carrier.clone()) =>
+            {
+                let ok_type = carrier_payload(expr_carrier.clone());
+                // TODO: previously, type unification was ran for T in
+                // case of a [Result<_,T>]. Feels like either it was
+                // unnecessary, or we should check unification
+                // succeeds for every type involved in the carrier
+                // (i.e. [A] and [B] for [Result<A,B>] and [A] for
+                // [Option<A>]).
+                Ok(((Borrowing::Consumed, ok_type.1), ok_type))
+            }
+            (Ok(expr_carrier), _) => {
+                sess.span_rustspec_err(
+                    return_typ.1,
+                    format!(
+                        "expected a {:?} type for this \
+			 return type because of a question mark in the function, got {}",
+                        carrier_kind(expr_carrier),
+                        return_typ.0,
+                    )
+                    .as_str(),
+                );
+                Err(())
             }
         }
+    } else {
+        Ok(expr_typ)
     }
-    Ok(expr_typ)
 }
 
 fn early_return_type_from_return_type(

--- a/language/src/typechecker.rs
+++ b/language/src/typechecker.rs
@@ -664,7 +664,7 @@ fn typecheck_expression(
     log::trace!("   {:?}", backtrace::Backtrace::new());
     match e {
         Expression::MonadicLet(..) => {
-            // TODO: use GADT to eliminiate this `panic!`
+            // TODO: eliminiate this `panic!` with nicer types (See issue #303)
             panic!("Expression::MonadicLet should be elaborated only after typechecking")
         }
         Expression::QuestionMark(qe, ..) => {

--- a/language/src/typechecker.rs
+++ b/language/src/typechecker.rs
@@ -2354,6 +2354,52 @@ fn early_return_type_from_return_type(
     }
 }
 
+/// Typechecks an expression, then elaborates
+/// [`MonadicLet`][Expression::MonadicLet] nodes, and possibly extract
+/// an [`EarlyReturnType`][EarlyReturnType].
+fn typecheck_expression_qm(
+    sess: &Session,
+    e: &Spanned<Expression>,
+    func_return_type: &Option<&Spanned<BaseTyp>>,
+    top_level_context: &TopLevelContext,
+    var_context: &VarContext,
+) -> TypecheckingResult<(Expression, Typ, Option<EarlyReturnType>, VarContext)> {
+    let (e, ty, vctx) =
+        typecheck_expression(sess, e, func_return_type, top_level_context, var_context)?;
+    let e = crate::elab_monadic_lets::eliminate_question_marks_in_expressions(&e);
+    Ok((
+        e.clone(),
+        ty,
+        match e {
+            Expression::MonadicLet(carrier, ..) => Some(carrier_kind(carrier)),
+            _ => None,
+        },
+        vctx,
+    ))
+}
+
+/// Typechecks and elaborate an expression which is expected to
+/// contain no question mark. In the case the expression is monadic
+/// (i.e. contains a question mark), the function throws an error.
+fn typecheck_expression_no_qm(
+    sess: &Session,
+    (e, e_span): &Spanned<Expression>,
+    func_return_type: &Option<&Spanned<BaseTyp>>,
+    top_level_context: &TopLevelContext,
+    var_context: &VarContext,
+) -> TypecheckingResult<(Expression, Typ, VarContext)> {
+    let e = &(e.clone(), e_span.clone());
+    let (e, ty, carrier, vctx) =
+        typecheck_expression_qm(sess, e, func_return_type, top_level_context, var_context)?;
+    match carrier {
+        Some(_) => Err(sess.span_rustspec_err(
+            *e_span,
+            format!("question mark cannot occur in this expression in Hacspec").as_str(),
+        )),
+        _ => Ok((e, ty, vctx)),
+    }
+}
+
 fn typecheck_statement(
     sess: &Session,
     (s, s_span): Spanned<Statement>,
@@ -2368,7 +2414,7 @@ fn typecheck_statement(
             log::trace!("       expr: {:?}", expr);
             #[cfg(feature = "dev")]
             log::trace!("   {:?}", backtrace::Backtrace::new());
-            let (new_expr, expr_typ, new_var_context) = typecheck_expression(
+            let (new_expr, expr_typ, carrier, new_var_context) = typecheck_expression_qm(
                 sess,
                 expr,
                 &Some(return_typ),
@@ -2383,6 +2429,7 @@ fn typecheck_statement(
                 expr.1.clone(),
                 top_level_context,
             )?;
+            let question_mark = *question_mark || matches!(carrier, Some(..));
             let typ = match typ {
                 None => Some((expr_typ.clone(), expr.1.clone())),
                 Some((inner_typ, _)) => {
@@ -2429,7 +2476,7 @@ fn typecheck_statement(
                     (pat.clone(), pat_span.clone()),
                     typ.clone(),
                     (new_expr, expr.1.clone()),
-                    *question_mark,
+                    question_mark,
                 ),
                 ((Borrowing::Consumed, s_span), (BaseTyp::Unit, s_span)),
                 new_var_context.clone().union(pat_var_context),
@@ -2438,8 +2485,13 @@ fn typecheck_statement(
         }
         Statement::Reassignment((x, x_span), e, question_mark) => {
             log::trace!("   Statement::Reassignment");
-            let (new_e, e_typ, new_var_context) =
-                typecheck_expression(sess, &e, &Some(return_typ), top_level_context, var_context)?;
+            let (new_e, e_typ, carrier, new_var_context) = typecheck_expression_qm(
+                sess,
+                &e,
+                &Some(return_typ),
+                top_level_context,
+                var_context,
+            )?;
             let e_typ = typecheck_question_mark(
                 sess,
                 *question_mark,
@@ -2448,6 +2500,7 @@ fn typecheck_statement(
                 e.1.clone(),
                 top_level_context,
             )?;
+            let question_mark = *question_mark || matches!(carrier, Some(..));
             let x_typ = find_typ(&x, var_context, top_level_context);
             let x_typ = match x_typ {
                 Some(t) => t,
@@ -2470,7 +2523,7 @@ fn typecheck_statement(
                 Statement::Reassignment(
                     (x.clone(), x_span.clone()),
                     (new_e, e.1.clone()),
-                    *question_mark,
+                    question_mark,
                 ),
                 ((Borrowing::Consumed, s_span), (BaseTyp::Unit, s_span)),
                 add_var(&x, &x_typ, &new_var_context),
@@ -2482,9 +2535,14 @@ fn typecheck_statement(
         }
         Statement::ArrayUpdate((x, x_span), e1, e2, question_mark, _) => {
             log::trace!("   Statement::ArrayUpdate");
-            let (new_e1, e1_t, var_context) =
-                typecheck_expression(sess, &e1, &Some(return_typ), top_level_context, var_context)?;
-            let (new_e2, e2_t, var_context) = typecheck_expression(
+            let (new_e1, e1_t, carrier1, var_context) = typecheck_expression_qm(
+                sess,
+                &e1,
+                &Some(return_typ),
+                top_level_context,
+                var_context,
+            )?;
+            let (new_e2, e2_t, carrier2, var_context) = typecheck_expression_qm(
                 sess,
                 &e2,
                 &Some(return_typ),
@@ -2499,6 +2557,8 @@ fn typecheck_statement(
                 e2.1.clone(),
                 top_level_context,
             )?;
+            let question_mark =
+                *question_mark || matches!(carrier1, Some(_)) || matches!(carrier2, Some(_));
             if !is_index(&(e1_t.1).0, top_level_context) {
                 sess.span_rustspec_err(
                     e1.1,
@@ -2543,7 +2603,7 @@ fn typecheck_statement(
                     (x.clone(), x_span.clone()),
                     (new_e1, e1.1.clone()),
                     (new_e2, e2.1.clone()),
-                    *question_mark,
+                    question_mark,
                     Some(x_typ),
                 ),
                 ((Borrowing::Consumed, s_span), (BaseTyp::Unit, s_span)),
@@ -2556,7 +2616,7 @@ fn typecheck_statement(
         }
         Statement::ReturnExp(e) => {
             log::trace!("   Statement::ReturnExp");
-            let (new_e, e_t, var_context) = typecheck_expression(
+            let (new_e, e_t, _, var_context) = typecheck_expression_qm(
                 sess,
                 &(e.clone(), s_span),
                 &Some(return_typ),
@@ -2573,7 +2633,7 @@ fn typecheck_statement(
         Statement::Conditional(cond, (b1, b1_span), b2, _) => {
             log::trace!("   Statement::Conditional");
             let original_var_context = var_context;
-            let (new_cond, cond_t, var_context) = typecheck_expression(
+            let (new_cond, cond_t, var_context) = typecheck_expression_no_qm(
                 sess,
                 &cond,
                 &Some(return_typ),
@@ -2682,10 +2742,20 @@ fn typecheck_statement(
         Statement::ForLoop(x, e1, e2, (b, b_span)) => {
             log::trace!("   Statement::ForLoop");
             let original_var_context = var_context;
-            let (new_e1, t_e1, var_context) =
-                typecheck_expression(sess, e1, &Some(return_typ), top_level_context, var_context)?;
-            let (new_e2, t_e2, var_context) =
-                typecheck_expression(sess, e2, &Some(return_typ), top_level_context, &var_context)?;
+            let (new_e1, t_e1, var_context) = typecheck_expression_no_qm(
+                sess,
+                e1,
+                &Some(return_typ),
+                top_level_context,
+                var_context,
+            )?;
+            let (new_e2, t_e2, var_context) = typecheck_expression_no_qm(
+                sess,
+                e2,
+                &Some(return_typ),
+                top_level_context,
+                &var_context,
+            )?;
             match (
                 t_e1.0.clone(),
                 dealias_type(t_e1.1 .0.clone(), top_level_context),
@@ -2855,8 +2925,13 @@ fn typecheck_item(
     let i = match &i {
         Item::NaturalIntegerDecl(typ_ident, secrecy, canvas_size, info) => {
             let canvas_size_span = canvas_size.1.clone();
-            let (new_canvas_size, canvas_size_typ, _) =
-                typecheck_expression(sess, canvas_size, &None, top_level_context, &HashMap::new())?;
+            let (new_canvas_size, canvas_size_typ, _) = typecheck_expression_no_qm(
+                sess,
+                canvas_size,
+                &None,
+                top_level_context,
+                &HashMap::new(),
+            )?;
             if let None = unify_types(
                 sess,
                 &(
@@ -2929,7 +3004,7 @@ fn typecheck_item(
         }
         Item::ArrayDecl(id, size, cell_t, index_typ) => {
             let (new_size, size_typ, _) =
-                typecheck_expression(sess, size, &None, top_level_context, &HashMap::new())?;
+                typecheck_expression_no_qm(sess, size, &None, top_level_context, &HashMap::new())?;
             if let None = unify_types(
                 sess,
                 &(
@@ -2959,7 +3034,7 @@ fn typecheck_item(
         }
         Item::ConstDecl(id, typ, e) => {
             let (new_e, new_t, _) =
-                typecheck_expression(sess, e, &None, top_level_context, &HashMap::new())?;
+                typecheck_expression_no_qm(sess, e, &None, top_level_context, &HashMap::new())?;
             if let None = unify_types(
                 sess,
                 &((Borrowing::Consumed, typ.1.clone()), typ.clone()),

--- a/language/src/typechecker.rs
+++ b/language/src/typechecker.rs
@@ -653,6 +653,7 @@ pub type TypecheckingResult<T> = Result<T, ()>;
 fn typecheck_expression(
     sess: &Session,
     (e, span): &Spanned<Expression>,
+    func_return_type: &Option<&Spanned<BaseTyp>>,
     top_level_context: &TopLevelContext,
     var_context: &VarContext,
 ) -> TypecheckingResult<(Expression, Typ, VarContext)> {
@@ -666,7 +667,13 @@ fn typecheck_expression(
                 .iter()
                 .map(|arg| {
                     let (new_arg, ((arg_typ_borrowing, _), arg_typ), new_var_context) =
-                        typecheck_expression(sess, arg, top_level_context, &var_context)?;
+                        typecheck_expression(
+                            sess,
+                            arg,
+                            func_return_type,
+                            top_level_context,
+                            &var_context,
+                        )?;
                     var_context = new_var_context;
                     match arg_typ_borrowing {
                         Borrowing::Borrowed => {
@@ -723,7 +730,7 @@ fn typecheck_expression(
         }
         Expression::MatchWith(arg, arms) => {
             let (new_arg, t_arg, intermediate_var_context) =
-                typecheck_expression(sess, arg, top_level_context, &var_context)?;
+                typecheck_expression(sess, arg, func_return_type, top_level_context, &var_context)?;
             let mut acc_var_context = intermediate_var_context.clone();
             // First we retrieve the enum type that's being matched on as well
             // as diverse infos related to it
@@ -930,6 +937,7 @@ fn typecheck_expression(
                         let (new_arm_exp, arm_typ, new_var_context) = typecheck_expression(
                             sess,
                             arm_exp,
+                            func_return_type,
                             top_level_context,
                             &intermediate_var_context.clone().union(new_var_context),
                         )?;
@@ -1029,6 +1037,7 @@ fn typecheck_expression(
                     let (new_payload, payload_type, new_var_context) = typecheck_expression(
                         sess,
                         &(*payload.clone(), payload_span.clone()),
+                        func_return_type,
                         top_level_context,
                         &var_context,
                     )?;
@@ -1060,8 +1069,13 @@ fn typecheck_expression(
             ))
         }
         Expression::InlineConditional(cond, e_t, e_f) => {
-            let (new_cond, t_cond, var_context) =
-                typecheck_expression(sess, cond, top_level_context, &var_context)?;
+            let (new_cond, t_cond, var_context) = typecheck_expression(
+                sess,
+                cond,
+                func_return_type,
+                top_level_context,
+                &var_context,
+            )?;
             unify_types_default_error_message(
                 sess,
                 &t_cond,
@@ -1073,9 +1087,9 @@ fn typecheck_expression(
                 top_level_context,
             )?;
             let (new_e_t, t_e_t, var_context_true_branch) =
-                typecheck_expression(sess, e_t, top_level_context, &var_context)?;
+                typecheck_expression(sess, e_t, func_return_type, top_level_context, &var_context)?;
             let (new_e_f, t_e_f, var_context_false_branch) =
-                typecheck_expression(sess, e_f, top_level_context, &var_context)?;
+                typecheck_expression(sess, e_f, func_return_type, top_level_context, &var_context)?;
             let final_var_context = var_context
                 .clone()
                 .intersection(var_context_true_branch)
@@ -1099,9 +1113,9 @@ fn typecheck_expression(
         }
         Expression::Binary((op, op_span), e1, e2, _) => {
             let (new_e1, t1, var_context) =
-                typecheck_expression(sess, e1, top_level_context, var_context)?;
+                typecheck_expression(sess, e1, func_return_type, top_level_context, var_context)?;
             let (new_e2, t2, var_context) =
-                typecheck_expression(sess, e2, top_level_context, &var_context)?;
+                typecheck_expression(sess, e2, func_return_type, top_level_context, &var_context)?;
             match op {
                 BinOpKind::Shl | BinOpKind::Shr => match &(t2.1).0 {
                     BaseTyp::UInt32 | BaseTyp::Usize => {
@@ -1219,7 +1233,7 @@ fn typecheck_expression(
         }
         Expression::Unary(op, e1, _) => {
             let (new_e1, e1_typ, new_var_context) =
-                typecheck_expression(sess, e1, top_level_context, var_context)?;
+                typecheck_expression(sess, e1, func_return_type, top_level_context, var_context)?;
             Ok((
                 Expression::Unary(
                     op.clone(),
@@ -1404,6 +1418,7 @@ fn typecheck_expression(
                                     typecheck_expression(
                                         sess,
                                         element,
+                                        func_return_type,
                                         top_level_context,
                                         &var_context,
                                     )?;
@@ -1468,6 +1483,7 @@ fn typecheck_expression(
                                     typecheck_expression(
                                         sess,
                                         element,
+                                        func_return_type,
                                         top_level_context,
                                         &var_context,
                                     )?;
@@ -1554,7 +1570,7 @@ fn typecheck_expression(
                 Some(t) => t,
             };
             let (new_e2, t2, var_context) =
-                typecheck_expression(sess, e2, top_level_context, &var_context)?;
+                typecheck_expression(sess, e2, func_return_type, top_level_context, &var_context)?;
             let (_, (cell_t, cell_t_span)) = is_array(sess, &t1, top_level_context, x_span)?;
             // We ignore t1.0 because we can read from both consumed and borrowed array types
             if let Borrowing::Borrowed = (t2.0).0 {
@@ -1636,6 +1652,7 @@ fn typecheck_expression(
                 let (new_arg, arg_t, new_var_context) = typecheck_expression(
                     sess,
                     &(arg.clone(), arg_span.clone()),
+                    func_return_type,
                     top_level_context,
                     &var_context,
                 )?;
@@ -1720,8 +1737,13 @@ fn typecheck_expression(
             let mut var_context = var_context.clone();
             // We omit to take the new var context because it will be retypechecked later, this
             // is just to determine wich type the method belongs to
-            let (_, sel_typ, _) =
-                typecheck_expression(sess, &sel, top_level_context, &var_context)?;
+            let (_, sel_typ, _) = typecheck_expression(
+                sess,
+                &sel,
+                func_return_type,
+                top_level_context,
+                &var_context,
+            )?;
             let (f_sig, typ_var_ctx) = find_func(
                 sess,
                 &FnKey::Impl((sel_typ.1).0.clone(), f.clone()),
@@ -1779,6 +1801,7 @@ fn typecheck_expression(
                 let (new_arg, arg_t, new_var_context) = typecheck_expression(
                     sess,
                     &(arg.clone(), arg_span.clone()),
+                    func_return_type,
                     top_level_context,
                     &var_context,
                 )?;
@@ -1859,7 +1882,7 @@ fn typecheck_expression(
             // log::trace!("         top level context {}", top_level_context);
             // log::trace!("          variable context {:?}", var_context);
             let (new_e1, e1_typ, var_context) =
-                typecheck_expression(sess, e1, top_level_context, var_context)?;
+                typecheck_expression(sess, e1, func_return_type, top_level_context, var_context)?;
             if (e1_typ.0).0 == Borrowing::Borrowed {
                 sess.span_rustspec_err(e1.1.clone(), "cannot cast borrowed expression");
                 return Err(());
@@ -2247,8 +2270,13 @@ fn typecheck_statement(
             log::trace!("       expr: {:?}", expr);
             #[cfg(feature = "dev")]
             log::trace!("   {:?}", backtrace::Backtrace::new());
-            let (new_expr, expr_typ, new_var_context) =
-                typecheck_expression(sess, expr, top_level_context, var_context)?;
+            let (new_expr, expr_typ, new_var_context) = typecheck_expression(
+                sess,
+                expr,
+                &Some(return_typ),
+                top_level_context,
+                var_context,
+            )?;
             let expr_typ = typecheck_question_mark(
                 sess,
                 *question_mark,
@@ -2313,7 +2341,7 @@ fn typecheck_statement(
         Statement::Reassignment((x, x_span), e, question_mark) => {
             log::trace!("   Statement::Reassignment");
             let (new_e, e_typ, new_var_context) =
-                typecheck_expression(sess, &e, top_level_context, var_context)?;
+                typecheck_expression(sess, &e, &Some(return_typ), top_level_context, var_context)?;
             let e_typ = typecheck_question_mark(
                 sess,
                 *question_mark,
@@ -2357,9 +2385,14 @@ fn typecheck_statement(
         Statement::ArrayUpdate((x, x_span), e1, e2, question_mark, _) => {
             log::trace!("   Statement::ArrayUpdate");
             let (new_e1, e1_t, var_context) =
-                typecheck_expression(sess, &e1, top_level_context, var_context)?;
-            let (new_e2, e2_t, var_context) =
-                typecheck_expression(sess, &e2, top_level_context, &var_context)?;
+                typecheck_expression(sess, &e1, &Some(return_typ), top_level_context, var_context)?;
+            let (new_e2, e2_t, var_context) = typecheck_expression(
+                sess,
+                &e2,
+                &Some(return_typ),
+                top_level_context,
+                &var_context,
+            )?;
             let e2_t = typecheck_question_mark(
                 sess,
                 *question_mark,
@@ -2425,8 +2458,13 @@ fn typecheck_statement(
         }
         Statement::ReturnExp(e) => {
             log::trace!("   Statement::ReturnExp");
-            let (new_e, e_t, var_context) =
-                typecheck_expression(sess, &(e.clone(), s_span), top_level_context, var_context)?;
+            let (new_e, e_t, var_context) = typecheck_expression(
+                sess,
+                &(e.clone(), s_span),
+                &Some(return_typ),
+                top_level_context,
+                var_context,
+            )?;
             Ok((
                 Statement::ReturnExp(new_e),
                 e_t,
@@ -2437,8 +2475,13 @@ fn typecheck_statement(
         Statement::Conditional(cond, (b1, b1_span), b2, _) => {
             log::trace!("   Statement::Conditional");
             let original_var_context = var_context;
-            let (new_cond, cond_t, var_context) =
-                typecheck_expression(sess, &cond, top_level_context, var_context)?;
+            let (new_cond, cond_t, var_context) = typecheck_expression(
+                sess,
+                &cond,
+                &Some(return_typ),
+                top_level_context,
+                var_context,
+            )?;
             unify_types_default_error_message(
                 sess,
                 &cond_t,
@@ -2542,9 +2585,9 @@ fn typecheck_statement(
             log::trace!("   Statement::ForLoop");
             let original_var_context = var_context;
             let (new_e1, t_e1, var_context) =
-                typecheck_expression(sess, e1, top_level_context, var_context)?;
+                typecheck_expression(sess, e1, &Some(return_typ), top_level_context, var_context)?;
             let (new_e2, t_e2, var_context) =
-                typecheck_expression(sess, e2, top_level_context, &var_context)?;
+                typecheck_expression(sess, e2, &Some(return_typ), top_level_context, &var_context)?;
             match (
                 t_e1.0.clone(),
                 dealias_type(t_e1.1 .0.clone(), top_level_context),
@@ -2715,7 +2758,7 @@ fn typecheck_item(
         Item::NaturalIntegerDecl(typ_ident, secrecy, canvas_size, info) => {
             let canvas_size_span = canvas_size.1.clone();
             let (new_canvas_size, canvas_size_typ, _) =
-                typecheck_expression(sess, canvas_size, top_level_context, &HashMap::new())?;
+                typecheck_expression(sess, canvas_size, &None, top_level_context, &HashMap::new())?;
             if let None = unify_types(
                 sess,
                 &(
@@ -2788,7 +2831,7 @@ fn typecheck_item(
         }
         Item::ArrayDecl(id, size, cell_t, index_typ) => {
             let (new_size, size_typ, _) =
-                typecheck_expression(sess, size, top_level_context, &HashMap::new())?;
+                typecheck_expression(sess, size, &None, top_level_context, &HashMap::new())?;
             if let None = unify_types(
                 sess,
                 &(
@@ -2818,7 +2861,7 @@ fn typecheck_item(
         }
         Item::ConstDecl(id, typ, e) => {
             let (new_e, new_t, _) =
-                typecheck_expression(sess, e, top_level_context, &HashMap::new())?;
+                typecheck_expression(sess, e, &None, top_level_context, &HashMap::new())?;
             if let None = unify_types(
                 sess,
                 &((Borrowing::Consumed, typ.1.clone()), typ.clone()),


### PR DESCRIPTION
Hi,

This PR allows question marks to appear anywhere in (most of) expressions, e.g., `f(x?) + g(y?)?`.
To do so, this PR adds the following nodes in the `Expression` enum:
 - `QuestionMark`, which simply reflects syntactically the presence of a question mark in an expression;
 - `MonadicLet`, which are elaborated from expressions containing `QuestionMark`, transforming and hoisting `QuestionMark`s in monadic bindings.

For now, there is some duplication between the code introduced by this PR and the existing code that handles question marks on statements. Also, "monadic" expressions are hoisted from the left to the right (e.g. `x.f y` with `x` and `y` monadic is elaborated to `x >>= (fun mx -> y >>= (fun my -> mx.f my)`): empirically that seems to match what Rust does, but I haven't found clear documentation about that.

This PR also adds basic support for those `MonadicLet` to the F* backend, but not to the Coq or Easycrypt backends.

I still have to write test cases for nested question marks.