### PR TITLE
Drop base type `Unit` in favor of empty tuple (Fixes #228 and #187)

### DIFF
--- a/language/language-tests/tuples.rs
+++ b/language/language-tests/tuples.rs
@@ -16,3 +16,11 @@ pub fn test_tuple_destructuring() {
     let tuple = MyTupleType(1u16, 2u8).clone();
     let MyTupleType(_a, _b) = tuple;
 }
+
+// Test case for issue #228
+pub fn unit_type() {
+    if true {
+        ()
+    };
+    ()
+}

--- a/language/src/ast_to_rustspec.rs
+++ b/language/src/ast_to_rustspec.rs
@@ -2508,7 +2508,7 @@ fn translate_items<F: Fn(&Vec<Spanned<String>>) -> ExternalData>(
             };
             let fn_inputs = check_vec(fn_inputs)?;
             let fn_output = match &sig.decl.output {
-                FnRetTy::Default(span) => (BaseTyp::Unit, span.clone().into()),
+                FnRetTy::Default(span) => (UnitTyp, span.clone().into()),
                 FnRetTy::Ty(ty) => translate_base_typ(sess, ty)?,
             };
             let fn_body: Spanned<Block> = match body {

--- a/language/src/rustspec.rs
+++ b/language/src/rustspec.rs
@@ -175,7 +175,6 @@ impl fmt::Debug for TypVar {
 
 #[derive(Clone, Hash, PartialEq, Eq, Serialize, Debug)]
 pub enum BaseTyp {
-    Unit,
     Bool,
     UInt128,
     Int128,
@@ -202,10 +201,11 @@ pub enum BaseTyp {
     NaturalInteger(Secrecy, Spanned<String>, Spanned<usize>), // secrecy, modulo value, encoding bits
 }
 
+pub const UnitTyp: BaseTyp = BaseTyp::Tuple(vec!());
+
 impl fmt::Display for BaseTyp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BaseTyp::Unit => write!(f, "unit"),
             BaseTyp::Bool => write!(f, "bool"),
             BaseTyp::UInt128 => write!(f, "u128"),
             BaseTyp::Int128 => write!(f, "i128"),

--- a/language/src/rustspec_to_coq.rs
+++ b/language/src/rustspec_to_coq.rs
@@ -251,7 +251,6 @@ fn translate_ident_str<'a>(ident_str: String) -> RcDoc<'a, ()> {
 
 fn translate_base_typ<'a>(tau: BaseTyp) -> RcDoc<'a, ()> {
     match tau {
-        BaseTyp::Unit => RcDoc::as_string("unit"),
         BaseTyp::Bool => RcDoc::as_string("bool"),
         BaseTyp::UInt8 => RcDoc::as_string("int8"),
         BaseTyp::Int8 => RcDoc::as_string("int8"),
@@ -493,7 +492,6 @@ fn translate_prefix_for_func_name<'a>(
 ) -> (RcDoc<'a, ()>, FuncPrefix) {
     match prefix {
         BaseTyp::Bool => panic!(), // should not happen
-        BaseTyp::Unit => panic!(), // should not happen
         BaseTyp::UInt8 => (RcDoc::as_string("pub_uint8"), FuncPrefix::Regular),
         BaseTyp::Int8 => (RcDoc::as_string("pub_int8"), FuncPrefix::Regular),
         BaseTyp::UInt16 => (RcDoc::as_string("pub_uint16"), FuncPrefix::Regular),
@@ -1490,7 +1488,7 @@ fn translate_block<'a>(
     let mut statements = b.stmts;
     match (&b.return_typ, omit_extra_unit) {
         (None, _) => panic!(), // should not happen,
-        (Some(((Borrowing::Consumed, _), (BaseTyp::Unit, _))), false) => {
+        (Some(((Borrowing::Consumed, _), (BaseTyp::Tuple(tup), _))), false) if tup.is_empty() => {
             statements.push((
                 Statement::ReturnExp(Expression::Lit(Literal::Unit)),
                 DUMMY_SP.into(),

--- a/language/src/rustspec_to_easycrypt.rs
+++ b/language/src/rustspec_to_easycrypt.rs
@@ -194,7 +194,6 @@ fn translate_ident_str<'a>(ident_str: String) -> RcDoc<'a, ()> {
 
 fn translate_base_typ<'a>(tau: BaseTyp) -> RcDoc<'a, ()> {
     match tau {
-        BaseTyp::Unit => RcDoc::as_string("unit"),
         BaseTyp::Bool => RcDoc::as_string("bool"),
         BaseTyp::UInt8 => RcDoc::as_string("pub_uint8"),
         BaseTyp::Int8 => RcDoc::as_string("pub_int8"),
@@ -238,6 +237,7 @@ fn translate_base_typ<'a>(tau: BaseTyp) -> RcDoc<'a, ()> {
             })
         }
         BaseTyp::Variable(id) => RcDoc::as_string(format!("'t{}", id.0)),
+	BaseTyp::Tuple(args) if args.is_empty() => RcDoc::as_string("unit"),
         BaseTyp::Tuple(args) => {
             make_typ_tuple(args.into_iter().map(|(arg, _)| translate_base_typ(arg)))
         }
@@ -542,7 +542,6 @@ fn translate_prefix_for_func_name<'a>(
 ) -> (RcDoc<'a, ()>, FuncPrefix) {
     match prefix {
         BaseTyp::Bool => panic!(), // should not happen
-        BaseTyp::Unit => panic!(), // should not happen
         BaseTyp::UInt8 => (RcDoc::as_string("pub_uint8"), FuncPrefix::Regular),
         BaseTyp::Int8 => (RcDoc::as_string("pub_int8"), FuncPrefix::Regular),
         BaseTyp::UInt16 => (RcDoc::as_string("pub_uint16"), FuncPrefix::Regular),
@@ -994,7 +993,7 @@ fn translate_block<'a>(
     )
     .append(match (&b.return_typ, omit_extra_unit) {
         (None, _) => panic!(), // should not happen,
-        (Some(((Borrowing::Consumed, _), (BaseTyp::Unit, _))), false) => {
+        (Some(((Borrowing::Consumed, _), (BaseTyp::Tuple(tup), _))), false) if tup.is_empty() => {
             RcDoc::hardline().append(RcDoc::as_string("()"))
         }
         (Some(_), _) => RcDoc::nil(),
@@ -1031,12 +1030,6 @@ fn translate_item<'a>(i: &'a DecoratedItem, top_ctx: &'a TopLevelContext) -> RcD
                 ),
             None,
             translate_block(b, false, top_ctx)
-                .append(if let BaseTyp::Unit = sig.ret.0 {
-                    RcDoc::hardline().append(RcDoc::as_string("()"))
-                } else {
-                    RcDoc::nil()
-                })
-                .group(),
         ),
         Item::ArrayDecl(name, size, cell_t, index_typ) => RcDoc::as_string("type")
             .append(RcDoc::space())

--- a/language/src/rustspec_to_fstar.rs
+++ b/language/src/rustspec_to_fstar.rs
@@ -260,7 +260,6 @@ fn translate_enum_case_name<'a>(enum_name: BaseTyp, case_name: TopLevelIdent) ->
 
 fn translate_base_typ<'a>(tau: BaseTyp) -> RcDoc<'a, ()> {
     match tau {
-        BaseTyp::Unit => RcDoc::as_string("unit"),
         BaseTyp::Bool => RcDoc::as_string("bool"),
         BaseTyp::UInt8 => RcDoc::as_string("pub_uint8"),
         BaseTyp::Int8 => RcDoc::as_string("pub_int8"),
@@ -309,6 +308,7 @@ fn translate_base_typ<'a>(tau: BaseTyp) -> RcDoc<'a, ()> {
             ),
         },
         BaseTyp::Variable(id) => RcDoc::as_string(format!("'t{}", id.0)),
+        BaseTyp::Tuple(args) if args.is_empty() => RcDoc::as_string("unit"),
         BaseTyp::Tuple(args) => {
             make_typ_tuple(args.into_iter().map(|(arg, _)| translate_base_typ(arg)))
         }
@@ -620,7 +620,6 @@ fn translate_prefix_for_func_name<'a>(
 ) -> (RcDoc<'a, ()>, FuncPrefix) {
     match prefix {
         BaseTyp::Bool => panic!(), // should not happen
-        BaseTyp::Unit => panic!(), // should not happen
         BaseTyp::UInt8 => (RcDoc::as_string("pub_uint8"), FuncPrefix::Regular),
         BaseTyp::Int8 => (RcDoc::as_string("pub_int8"), FuncPrefix::Regular),
         BaseTyp::UInt16 => (RcDoc::as_string("pub_uint16"), FuncPrefix::Regular),
@@ -1301,7 +1300,7 @@ fn translate_block<'a>(
     let mut statements = b.stmts;
     match (&b.return_typ, omit_extra_unit) {
         (None, _) => panic!(), // should not happen,
-        (Some(((Borrowing::Consumed, _), (BaseTyp::Unit, _))), false) => {
+        (Some(((Borrowing::Consumed, _), (BaseTyp::Tuple(tup), _))), false) if tup.is_empty() => {
             statements.push((
                 Statement::ReturnExp(Expression::Lit(Literal::Unit)),
                 DUMMY_SP.into(),
@@ -1345,13 +1344,7 @@ fn translate_item<'a>(
                         .group(),
                 ),
             None,
-            translate_block(sess, b.clone(), false, top_ctx)
-                .append(if let BaseTyp::Unit = sig.ret.0 {
-                    RcDoc::hardline().append(RcDoc::as_string("()"))
-                } else {
-                    RcDoc::nil()
-                })
-                .group(),
+            translate_block(sess, b.clone(), false, top_ctx),
             true,
         ),
         Item::EnumDecl(name, cases) => RcDoc::as_string("noeq type")

--- a/language/src/typechecker.rs
+++ b/language/src/typechecker.rs
@@ -76,7 +76,6 @@ fn is_bool(t: &Typ, top_ctxt: &TopLevelContext) -> bool {
 
 fn is_copy(t: &BaseTyp, top_ctxt: &TopLevelContext) -> bool {
     match t {
-        BaseTyp::Unit => true,
         BaseTyp::Bool => true,
         BaseTyp::UInt128 => true,
         BaseTyp::Int128 => true,
@@ -336,7 +335,6 @@ fn unify_types(
     match (&(t1.0).0, &(t2.0).0) {
         (Borrowing::Consumed, Borrowing::Consumed) | (Borrowing::Borrowed, Borrowing::Borrowed) => {
             match (&(t1.1).0, &(t2.1).0) {
-                (BaseTyp::Unit, BaseTyp::Unit) => Ok(Some(typ_ctx.clone())),
                 (BaseTyp::Bool, BaseTyp::Bool) => Ok(Some(typ_ctx.clone())),
                 (BaseTyp::UInt128, BaseTyp::UInt128) => Ok(Some(typ_ctx.clone())),
                 (BaseTyp::Int128, BaseTyp::Int128) => Ok(Some(typ_ctx.clone())),
@@ -1235,7 +1233,7 @@ fn typecheck_expression(
                 e.clone(),
                 (
                     (Borrowing::Consumed, span.clone()),
-                    (BaseTyp::Unit, span.clone()),
+                    (UnitTyp, span.clone()),
                 ),
                 var_context.clone(),
             )),
@@ -2305,7 +2303,7 @@ fn typecheck_statement(
                     (new_expr, expr.1.clone()),
                     *question_mark,
                 ),
-                ((Borrowing::Consumed, s_span), (BaseTyp::Unit, s_span)),
+                ((Borrowing::Consumed, s_span), (UnitTyp, s_span)),
                 new_var_context.clone().union(pat_var_context),
                 VarSet(HashSet::new()),
             ))
@@ -2346,7 +2344,7 @@ fn typecheck_statement(
                     (new_e, e.1.clone()),
                     *question_mark,
                 ),
-                ((Borrowing::Consumed, s_span), (BaseTyp::Unit, s_span)),
+                ((Borrowing::Consumed, s_span), (UnitTyp, s_span)),
                 add_var(&x, &x_typ, &new_var_context),
                 VarSet(HashSet::unit(match x.clone() {
                     Ident::Local(x) => x,
@@ -2415,7 +2413,7 @@ fn typecheck_statement(
                     *question_mark,
                     Some(x_typ),
                 ),
-                ((Borrowing::Consumed, s_span), (BaseTyp::Unit, s_span)),
+                ((Borrowing::Consumed, s_span), (UnitTyp, s_span)),
                 var_context,
                 VarSet(HashSet::unit(match x.clone() {
                     Ident::Local(x) => x,
@@ -2471,7 +2469,7 @@ fn typecheck_statement(
             };
             match &new_b1.return_typ {
                 None => panic!("should not happen"),
-                Some(((Borrowing::Consumed, _), (BaseTyp::Unit, _))) => (),
+                Some(((Borrowing::Consumed, _), (BaseTyp::Tuple(tup), _))) if tup.is_empty() => (),
                 Some(((b_t, _), (t, _))) => {
                     sess.span_rustspec_err(
                         *b1_span,
@@ -2486,7 +2484,7 @@ fn typecheck_statement(
                 Some((new_b2, _)) => {
                     match &new_b2.return_typ {
                         None => panic!("should not happen"),
-                        Some(((Borrowing::Consumed, _), (BaseTyp::Unit, _))) => (),
+                        Some(((Borrowing::Consumed, _), (BaseTyp::Tuple(tup), _))) if tup.is_empty() => (),
                         Some(((b_t, _), (t, _))) => {
                             sess.span_rustspec_err(
                                 *b1_span,
@@ -2530,7 +2528,7 @@ fn typecheck_statement(
                         stmt: mut_tuple,
                     })),
                 ),
-                ((Borrowing::Consumed, s_span), (BaseTyp::Unit, s_span)),
+                ((Borrowing::Consumed, s_span), (UnitTyp, s_span)),
                 original_var_context
                     .clone()
                     .intersection(var_context_b1)
@@ -2615,7 +2613,7 @@ fn typecheck_statement(
                     (new_e2, e2.1.clone()),
                     (new_b, *b_span),
                 ),
-                ((Borrowing::Consumed, s_span), (BaseTyp::Unit, s_span)),
+                ((Borrowing::Consumed, s_span), (UnitTyp, s_span)),
                 original_var_context.clone().intersection(var_context),
                 mutated_vars,
             ))
@@ -2635,7 +2633,7 @@ fn typecheck_block(
     let mut mutated_vars = VarSet(HashSet::new());
     let mut return_typ = Some((
         (Borrowing::Consumed, DUMMY_SP.into()),
-        (BaseTyp::Unit, DUMMY_SP.into()),
+        (UnitTyp, DUMMY_SP.into()),
     ));
     let mut new_stmts = Vec::new();
     let n_stmts = b.stmts.len();
@@ -2655,7 +2653,7 @@ fn typecheck_block(
         if i + 1 < n_stmts {
             // Statement return types should be unit except for the last one
             match stmt_typ {
-                ((Borrowing::Consumed, _), (BaseTyp::Unit, _)) => (),
+                ((Borrowing::Consumed, _), (BaseTyp::Tuple(tup), _)) if tup.is_empty() => (),
                 _ => {
                     sess.span_rustspec_err(s_span, "statement shoud have an unit type here");
                     return Err(());


### PR DESCRIPTION
Hi,

As per issue #187, Hacspec used to treat `unit` and `()` as two different types, causing e.g. issue #228.
This PR thus drops the constructor `BaseTyp::Unit`, in favor of `BaseTyp::Tuple(!vec[])`.