### PR TITLE
Support struct whose payload is `()` (fixes #287)

### DIFF
--- a/language/language-tests/tuples.rs
+++ b/language/language-tests/tuples.rs
@@ -16,3 +16,9 @@ pub fn test_tuple_destructuring() {
     let tuple = MyTupleType(1u16, 2u8).clone();
     let MyTupleType(_a, _b) = tuple;
 }
+
+// Issue #287
+pub struct EmptyTuple();
+pub fn test_empty_tuple() -> EmptyTuple {
+    EmptyTuple()
+}

--- a/language/src/ast_to_rustspec.rs
+++ b/language/src/ast_to_rustspec.rs
@@ -667,11 +667,9 @@ fn translate_expr(
                             ExprTranslationResult::TransExpr(Expression::EnumInject(
                                 BaseTyp::Named(func_name_but_as_type, None),
                                 func_name_but_as_enum_constructor,
-                                Some(if func_args.len() > 1 {
-                                    (Box::new(Expression::Tuple(func_args)), e.span.into())
-                                } else {
-                                    let arg = func_args.into_iter().next().unwrap();
-                                    (Box::new(arg.0), arg.1)
+                                Some(match func_args.as_slice() {
+                                    [arg] => (Box::new(arg.0.clone()), arg.1),
+                                    _ => (Box::new(Expression::Tuple(func_args)), e.span.into()),
                                 }),
                             )),
                             e.span.into(),
@@ -2831,10 +2829,9 @@ fn translate_items<F: Fn(&Vec<Spanned<String>>) -> ExternalData>(
                             })
                             .collect(),
                     )?;
-                    let payload = if tuple_args.len() > 1 {
-                        (BaseTyp::Tuple(tuple_args), i.span.clone().into())
-                    } else {
-                        tuple_args.into_iter().next().unwrap()
+                    let payload = match tuple_args.as_slice() {
+                        [arg] => arg.clone(),
+                        _ => (BaseTyp::Tuple(tuple_args), i.span.clone().into()),
                     };
                     Ok((
                         ItemTranslationResult::Item(DecoratedItem {


### PR DESCRIPTION
As @cmester0 described in #287, a struct with an empty tuple used to result in a panic in module `ast_to_rustspec`.
For example, the following snippet was problematic:
```rust
pub struct EmptyTuple();
pub fn test_empty_tuple() -> EmptyTuple {
    EmptyTuple()
}
```

This PR just reformulates two `unwrap`s into pattern matching and adds a test case.