### PR TITLE
Allow unannotated integer literals 

### DIFF
--- a/language/language-tests/literals.rs
+++ b/language/language-tests/literals.rs
@@ -1,0 +1,5 @@
+fn unannotated_literals() -> u8 {
+    let _x: i64 = 123;
+    let _x: u32 = 88;
+    42
+}

--- a/language/language-tests/result.rs
+++ b/language/language-tests/result.rs
@@ -67,8 +67,8 @@ fn no_annotation_nested() -> Result<u8, u16> {
         Err(1u16)
     } else {
         match Result::<u8, u16>::Ok(12u8) {
-            Result::<u8, u16>::Ok(x) => Err(x as u16),
-            Result::<u8, u16>::Err(_x) => Ok(1u8),
+            Ok(x) => Err(x as u16),
+            Err(_x) => Ok(1u8),
         }
     }
 }
@@ -86,8 +86,8 @@ fn no_annotation_tuple() -> (Result<(), u16>, Result<u8, u16>) {
         (Ok(()), Err(1u16))
     } else {
         match Result::<u8, u16>::Ok(12u8) {
-            Result::<u8, u16>::Ok(x) => (Ok(()), Err(x as u16)),
-            Result::<u8, u16>::Err(_x) => (Ok(()), Ok(1u8)),
+            Ok(x) => (Ok(()), Err(x as u16)),
+            Err(_x) => (Ok(()), Ok(1u8)),
         }
     }
 }

--- a/language/src/ast_to_rustspec.rs
+++ b/language/src/ast_to_rustspec.rs
@@ -673,7 +673,8 @@ fn translate_expr(
                         func_name.1,
                     );
 
-                    // if we're facing a un-annotated constructor (that is, `func_prefix` is `None`) in the whitelist [Ok, Err], then, we return an `EnumInject` with a type `Placeholder`
+                    // if we're facing a un-annotated constructor (that is, `func_prefix` is `None`)
+                    // in the whitelist [Ok, Err], then, we return an `EnumInject` with a type `Placeholder`
                     if func_prefix.is_none() && ["Ok", "Err"].contains(&&*func_name_string) {
                         let func_args: Vec<TranslationResult<Spanned<Expression>>> = args
                             .iter()

--- a/language/src/ast_to_rustspec.rs
+++ b/language/src/ast_to_rustspec.rs
@@ -511,8 +511,7 @@ fn translate_literal(lit: &rustc_ast::Lit) -> Result<Literal, ()> {
         LitKind::Int(x, LitIntType::Unsigned(UintTy::U8)) => Ok(Literal::UInt8(*x as u8)),
         LitKind::Int(x, LitIntType::Signed(IntTy::Isize)) => Ok(Literal::Isize(*x as isize)),
         LitKind::Int(x, LitIntType::Unsigned(UintTy::Usize)) => Ok(Literal::Usize(*x as usize)),
-        // Unspecified integers are always interpreted as usize
-        LitKind::Int(x, LitIntType::Unsuffixed) => Ok(Literal::Usize(*x as usize)),
+        LitKind::Int(x, LitIntType::Unsuffixed) => Ok(Literal::UnspecifiedInt(*x)),
         LitKind::Str(msg, StrStyle::Cooked) => Ok(Literal::Str(msg.to_ident_string())),
         _ => Err(()),
     }

--- a/language/src/rustspec.rs
+++ b/language/src/rustspec.rs
@@ -287,6 +287,7 @@ pub enum Literal {
     UInt8(u8),
     Usize(usize),
     Isize(isize),
+    UnspecifiedInt(u128),
     Str(String),
 }
 

--- a/language/src/rustspec_to_coq.rs
+++ b/language/src/rustspec_to_coq.rs
@@ -336,6 +336,7 @@ fn translate_literal<'a>(lit: Literal) -> RcDoc<'a, ()> {
         Literal::UInt8(x) => RcDoc::as_string(format!("@repr WORDSIZE8 {}", x)),
         Literal::Isize(x) => RcDoc::as_string(format!("isize {}", x)),
         Literal::Usize(x) => RcDoc::as_string(format!("usize {}", x)),
+        Literal::UnspecifiedInt(_) => panic!("Got a `UnspecifiedInt` literal: those should have been resolved into concrete types during the typechecking phase"),
         Literal::Str(msg) => RcDoc::as_string(format!("\"{}\"", msg)),
     }
 }

--- a/language/src/rustspec_to_easycrypt.rs
+++ b/language/src/rustspec_to_easycrypt.rs
@@ -272,6 +272,7 @@ fn translate_literal<'a>(lit: Literal) -> RcDoc<'a, ()> {
         Literal::UInt8(x) => RcDoc::as_string(format!("pub_u8 {}", x)),
         Literal::Isize(x) => RcDoc::as_string(format!("{}", x)),
         Literal::Usize(x) => RcDoc::as_string(format!("{}", x)),
+        Literal::UnspecifiedInt(_) => panic!("Got a `UnspecifiedInt` literal: those should have been resolved into concrete types during the typechecking phase"),
         Literal::Str(msg) => RcDoc::as_string(format!("\"{}\"", msg)),
     }
 }

--- a/language/src/rustspec_to_fstar.rs
+++ b/language/src/rustspec_to_fstar.rs
@@ -374,6 +374,7 @@ fn translate_literal<'a>(lit: Literal) -> RcDoc<'a, ()> {
         Literal::UInt8(x) => RcDoc::as_string(format!("{:#x}uy", x)),
         Literal::Isize(x) => RcDoc::as_string(format!("{}", x)),
         Literal::Usize(x) => RcDoc::as_string(format!("{}", x)),
+        Literal::UnspecifiedInt(_) => panic!("Got a `UnspecifiedInt` literal: those should have been resolved into concrete types during the typechecking phase"),
         Literal::Str(msg) => RcDoc::as_string(format!("\"{}\"", msg)),
     }
 }

--- a/language/tests/0_language.rs
+++ b/language/tests/0_language.rs
@@ -67,6 +67,11 @@ fn positive_seq_ops() {
 }
 
 #[test]
+fn positive_literals() {
+    run_test("language-tests/literals.rs", Some("tests/"));
+}
+
+#[test]
 #[should_panic]
 fn negative_arrays() {
     run_test("negative-language-tests/arrays.rs", None);


### PR DESCRIPTION
### Type of Changes
<!--- Please select --->
- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI Update

### Description
Hacspec used to treat every unannotated integer literal (e.g. `42`, an integer without a suffix like `u8` or `i64`) as a `usize` integer.
This PR adds a new literal variant to Hacspec AST, `UnannotatedInt`, and every unannotated integer literal is interpreted as a `UnannotatedInt`.
Those are then concretized at typechecking.

This PR adds the test `positive_literals`.
This PR depends on #315 and #322.

### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Check the style of the commit messages matches our requested structure.
- [ ] Check that your commits do not fail any tests.
- [ ] Link to an open issue and assign yourself to the issue and the PR (if possible).
- [x] If this is a user-facing change please describe the changes in a single line that explains this improvement in terms that a user can understand.
- [ x What process did you follow to verify that your change has the desired effects?
- [x] Check that you are fine with the CLA below.

#### A good description answers the following questions.
- Is it possible to understand the design of your change from the description?
- What other alternatives were considered and why did you select the proposed version?
- What are the possible side-effects or negative impacts of the code change?
- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
- Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

### CLA
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the MIT license; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the MIT license; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

---

If it's not possible to get a good idea of what the code will be doing from the PR description here, the pull request may be closed. Keep in mind that the reviewer may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

💕 Thank you!
