### PR TITLE
Support field accessors on tuples and tuple structs

### DIFF
--- a/language/language-tests/enums.rs
+++ b/language/language-tests/enums.rs
@@ -74,3 +74,9 @@ pub fn baz_im(x: Foo) {
     let Bar(z) = z;
     let a = z as u8;
 }
+
+struct Foobar(u8, u8, u8);
+
+fn field_accessors() -> u8 {
+    Foobar(0u8, 1u8, 2u8).0 + Foobar(0u8, 1u8, 2u8).1 + Foobar(0u8, 1u8, 2u8).2 + (10u8, 20u8).1
+}

--- a/language/src/elab_monadic_lets.rs
+++ b/language/src/elab_monadic_lets.rs
@@ -176,6 +176,9 @@ pub fn eliminate_question_marks_in_expressions(e: &Expression) -> Expression {
                 Expression::MatchWith(scrutinee, branches.collect())
             }
         }
+        Expression::FieldAccessor(e1, field) => {
+            Expression::FieldAccessor(elim_boxed_sub_expr(e1), field.clone())
+        }
         Expression::ArrayIndex(n, e1, t) => {
             Expression::ArrayIndex(n.clone(), elim_boxed_sub_expr(e1), t.clone())
         }

--- a/language/src/main.rs
+++ b/language/src/main.rs
@@ -1,4 +1,6 @@
 #![feature(rustc_private)]
+#![feature(box_syntax)]
+#![feature(box_patterns)]
 extern crate im;
 extern crate pretty;
 extern crate rustc_ast;

--- a/language/src/name_resolution.rs
+++ b/language/src/name_resolution.rs
@@ -243,6 +243,10 @@ fn resolve_expression(
                 (Expression::MatchWith(Box::new(new_arg), new_arms), e_span),
             ))
         }
+        Expression::FieldAccessor(box e1, field) => {
+            let (smi, e1) = resolve_expression(sess, e1, name_context, top_level_ctx)?;
+            Ok((smi, (Expression::FieldAccessor(box e1, field), e_span)))
+        }
         Expression::EnumInject(enum_name, case_name, payload) => {
             let (smi_payload, payload) = match payload {
                 None => (ScopeMutInfo::new(), None),

--- a/language/src/rustspec.rs
+++ b/language/src/rustspec.rs
@@ -342,6 +342,16 @@ pub fn carrier_kind(carrier: CarrierTyp) -> EarlyReturnType {
     }
 }
 
+#[derive(Clone, Serialize, Debug, Copy)]
+/// Rust has three styles of structs: (a) unit structs, (b) classic,
+/// named structs (c) tuple structs. A field is thus either a numeric
+/// index or a name. However, Hacspec allows only for (a) or (c),
+/// hence the constructor `Named` being commented out below.
+pub enum Field {
+    // Named(String),
+    TupleIndex(isize),
+}
+
 #[derive(Clone, Serialize, Debug)]
 pub enum Expression {
     Unary(UnOpKind, Box<Spanned<Expression>>, Option<Typ>),
@@ -402,6 +412,7 @@ pub enum Expression {
             Spanned<Expression>, // Match arm expression
         )>,
     ),
+    FieldAccessor(Box<Spanned<Expression>>, Box<Spanned<Field>>),
     Lit(Literal),
     ArrayIndex(
         Spanned<Ident>,           // Array variable

--- a/language/src/rustspec_to_coq.rs
+++ b/language/src/rustspec_to_coq.rs
@@ -508,6 +508,9 @@ fn translate_expression<'a>(e: Expression, top_ctx: &'a TopLevelContext) -> RcDo
             ))
             .append(RcDoc::line())
             .append(RcDoc::as_string("end")),
+        Expression::FieldAccessor(e1, field) => {
+            unimplemented!()
+        }
         //todo
         Expression::EnumInject(enum_name, case_name, payload) => {
             translate_enum_case_name(enum_name.clone(), case_name.0.clone(), true).append(

--- a/language/src/rustspec_to_easycrypt.rs
+++ b/language/src/rustspec_to_easycrypt.rs
@@ -718,6 +718,9 @@ fn translate_expression<'a>(e: Expression, top_ctx: &'a TopLevelContext) -> RcDo
         Expression::MatchWith(_arg, _arms) => {
             unimplemented!()
         }
+        Expression::FieldAccessor(e1, field) => {
+            unimplemented!()
+        }
         Expression::EnumInject(_enum_name, _case_name, _payload) => {
             unimplemented!()
         }

--- a/language/src/rustspec_to_fstar.rs
+++ b/language/src/rustspec_to_fstar.rs
@@ -893,6 +893,13 @@ fn translate_expression<'a>(
             ))
             .append(RcDoc::space())
             .append("end"),
+        Expression::FieldAccessor(e1, box (Field::TupleIndex(field), _)) => {
+            // TODO: this works only for tuples because for now, a
+            // rust variant of arity [n] is extracted as an F* variant
+            // of arity [1] whose payload is a tuple of arity [n].
+            make_paren(translate_expression(sess, e1.0, top_ctx))
+                .append(RcDoc::as_string(format!("._{}", field)))
+        }
         Expression::EnumInject(enum_name, case_name, payload) => {
             translate_enum_case_name(enum_name.clone(), case_name.0.clone()).append(match payload {
                 None => RcDoc::nil(),

--- a/language/src/rustspec_to_fstar.rs
+++ b/language/src/rustspec_to_fstar.rs
@@ -894,9 +894,10 @@ fn translate_expression<'a>(
             .append(RcDoc::space())
             .append("end"),
         Expression::FieldAccessor(e1, box (Field::TupleIndex(field), _)) => {
-            // TODO: this works only for tuples because for now, a
-            // rust variant of arity [n] is extracted as an F* variant
-            // of arity [1] whose payload is a tuple of arity [n].
+            // TODO (See issue #325): this works only for tuples
+            // because for now, a rust variant of arity [n] is
+            // extracted as an F* variant of arity [1] whose payload
+            // is a tuple of arity [n].
             make_paren(translate_expression(sess, e1.0, top_ctx))
                 .append(RcDoc::as_string(format!("._{}", field)))
         }


### PR DESCRIPTION
### Type of Changes
<!--- Please select --->
- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI Update

### Description
This PR brings support for field accessors on tuples and tuple structs, one can now write `(x, y, z).2` or `Foo(x, y).0` (when `Foo` is a [tuple struct](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#using-tuple-structs-without-named-fields-to-create-different-types)).

### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Check the style of the commit messages matches our requested structure.
- [ ] Check that your commits do not fail any tests.
- [ ] Link to an open issue and assign yourself to the issue and the PR (if possible).
- [x] If this is a user-facing change please describe the changes in a single line that explains this improvement in terms that a user can understand.
- [ ] What process did you follow to verify that your change has the desired effects?
- [x] Check that you are fine with the CLA below.

#### A good description answers the following questions.
- Is it possible to understand the design of your change from the description?
- What other alternatives were considered and why did you select the proposed version?
- What are the possible side-effects or negative impacts of the code change?
- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
- Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

### CLA
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the MIT license; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the MIT license; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

---

If it's not possible to get a good idea of what the code will be doing from the PR description here, the pull request may be closed. Keep in mind that the reviewer may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

💕 Thank you!
