### PR TITLE
Allow unannonated `Some` and `None`

### DIFF
--- a/language/language-tests/option.rs
+++ b/language/language-tests/option.rs
@@ -8,3 +8,12 @@ pub fn foo(x: Option<Option<U32>>) -> U32 {
         Option::<Option<U32>>::Some(x) => x.unwrap(),
     }
 }
+
+pub fn foo_unannonated(x: Option<Option<U32>>) -> Option<U32> {
+    let _y: Option<U32> = None;
+    match x {
+        None => Some(U32(0u32)),
+        Some(None) => Some(U32(1u32)),
+        Some(Some(x)) => Some(x),
+    }
+}

--- a/language/src/typechecker.rs
+++ b/language/src/typechecker.rs
@@ -2020,7 +2020,14 @@ fn typecheck_pattern(
                         }
                         (Some(_), _) => failure("one case but no payload"),
                         (_, Some(_)) => failure("an unexpected payload"),
-                        _ => Ok((VarContext::new(), pat.clone())),
+                        _ => Ok((
+                            VarContext::new(),
+                            Pattern::EnumCase(
+                                ty_name.clone(),
+                                (pat_enum_name.clone(), pat_enum_name_span.clone()),
+                                None,
+                            ),
+                        )),
                     }
                 }
                 _ => {


### PR DESCRIPTION
### Type of Changes
<!--- Please select --->
- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] CI Update

### Description
I forgot to add `Some` and `None` to the whitelist of unannotated constructors.
Thus, this PR allows `Some` and `None` to be used without annotation.
This PR also fixes a few minor bugs. 

### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Check the style of the commit messages matches our requested structure.
- [ ] Check that your commits do not fail any tests.
- [ ] Link to an open issue and assign yourself to the issue and the PR (if possible).
- [x] If this is a user-facing change please describe the changes in a single line that explains this improvement in terms that a user can understand.
- [ ] What process did you follow to verify that your change has the desired effects?
- [x] Check that you are fine with the CLA below.

#### A good description answers the following questions.
- Is it possible to understand the design of your change from the description?
- What other alternatives were considered and why did you select the proposed version?
- What are the possible side-effects or negative impacts of the code change?
- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
- Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

### CLA
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the MIT license; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the MIT license; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

---

If it's not possible to get a good idea of what the code will be doing from the PR description here, the pull request may be closed. Keep in mind that the reviewer may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

💕 Thank you!
