### PR TITLE
Fast secret bytes for protocols

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -21,6 +21,7 @@ alloc = ["secret_integers"]
 std = ["alloc", "secret_integers", "num/std", "abstract_integers/std"]
 
 use_attributes = ["hacspec-attributes", "hacspec-attributes/print_attributes"]
+release = [] # A release mode for hacspec that disables some checks and doesn't use secret integers.
 
 [dev-dependencies]
 rand = "0.8"

--- a/lib/src/buf.rs
+++ b/lib/src/buf.rs
@@ -1,0 +1,96 @@
+//! # hacspec buffer
+//!
+//! A buffer for operating on hacspec bytes.
+
+use std::collections::VecDeque;
+
+use super::seq::*;
+use crate::prelude::*;
+
+#[derive(Debug, Clone)]
+pub struct ByteBuffer {
+    value: VecDeque<Bytes>,
+}
+
+impl ByteBuffer {
+    /// Create an empty buffer.
+    #[cfg_attr(feature = "use_attributes", in_hacspec)]
+    pub fn new() -> ByteBuffer {
+        Self {
+            value: VecDeque::new(),
+        }
+    }
+
+    /// Create a buffer from [`Bytes`].
+    #[cfg_attr(feature = "use_attributes", in_hacspec)]
+    pub fn from_seq(seq: Bytes) -> ByteBuffer {
+        let mut value: VecDeque<Bytes> = VecDeque::with_capacity(1);
+        value.push_back(seq);
+        Self { value }
+    }
+
+    /// Add a new chunk of [`Bytes`] to this [`ByteBuffer`].
+    #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
+    pub fn concat_owned(mut self, seq: Bytes) -> ByteBuffer {
+        self.value.push_back(seq);
+        self
+    }
+
+    /// Split off `num` bytes and return the [`Bytes`].
+    #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
+    pub fn split_off(mut self, len: usize) -> (Bytes, ByteBuffer) {
+        assert!(self.value.len() != 0, "The buffer is empty.");
+
+        if len == self.value[0].len() {
+            // This is the efficient case.
+            let val = self.value.pop_front().unwrap();
+            (val, self)
+        } else {
+            // Here we don't optimize and just take the first len bytes.
+            let mut out = self.value.pop_front().unwrap();
+            assert!(out.len() != len);
+            if out.len() > len {
+                let (full_out, to_keep) = out.split_off(len);
+                out = full_out;
+                self.value.push_front(to_keep);
+                return (out, self);
+            } else {
+                assert!(out.len() < len);
+                // Get more bytes until we have enough.
+                while out.len() < len {
+                    let next = self.value.pop_front().unwrap();
+                    if next.len() <= (len - out.len()) {
+                        out = out.concat_owned(next);
+                    } else {
+                        let (next, to_keep) = next.split_off(len - out.len());
+                        out = out.concat_owned(next);
+                        self.value.push_front(to_keep);
+                    }
+                }
+                return (out, self);
+            }
+        }
+    }
+
+    /// Get the buffer a single [`Bytes`] object (not efficient).
+    #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
+    pub fn to_bytes(&self) -> Bytes {
+        let mut out = Bytes::new(0);
+        for value in self.value.iter() {
+            out = out.concat_owned(value.clone());
+        }
+        out
+    }
+
+    /// Get the buffer a single [`Bytes`] object (efficient, consuming the buffer).
+    #[cfg_attr(feature = "use_attributes", unsafe_hacspec)]
+    pub fn into_bytes(mut self) -> Bytes {
+        self.value
+            .drain(..)
+            .fold(Bytes::new(0), |acc, next| acc.concat_owned(next))
+    }
+}
+
+// === Helper functions not in hacspec === //
+
+impl ByteBuffer {}

--- a/lib/src/buf.rs
+++ b/lib/src/buf.rs
@@ -2,7 +2,12 @@
 //!
 //! A buffer for operating on hacspec bytes.
 
-use std::collections::VecDeque;
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std as alloc;
+
+use alloc::collections::VecDeque;
 
 use super::seq::*;
 use crate::prelude::*;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -100,5 +100,6 @@ mod vec_integers;
 mod vec_integers_public;
 mod vec_integers_secret;
 mod vec_util;
+pub mod buf;
 
 pub use crate::prelude::*;

--- a/lib/src/prelude.rs
+++ b/lib/src/prelude.rs
@@ -6,6 +6,7 @@
 
 pub use crate::array::*;
 pub use crate::bigint_integers::*;
+pub use crate::buf::*;
 pub use crate::machine_integers::*;
 pub use crate::math_integers::*;
 pub use crate::math_util::{ct_util::*, *};

--- a/lib/src/seq/bytes.rs
+++ b/lib/src/seq/bytes.rs
@@ -1,0 +1,197 @@
+//! # Efficient and safe bytes
+//!
+//! [`Bytes`] can be used when secret byte sequences ([`ByteSeq`]) are used but
+//! they are too slow for using hacspec in a release version that interacts with
+//! other Rust code, i.e. requires a lot conversions between [`U8`] and [`u8`].
+#![allow(non_snake_case, dead_code)]
+
+use super::*;
+
+#[cfg(feature = "release")]
+pub type Byte = u8;
+#[cfg(not(feature = "release"))]
+pub type Byte = U8;
+
+#[cfg(feature = "release")]
+pub type DoubleByte = u16;
+#[cfg(not(feature = "release"))]
+pub type DoubleByte = U16;
+
+#[cfg(feature = "release")]
+pub type QuadByte = u32;
+#[cfg(not(feature = "release"))]
+pub type QuadByte = U32;
+
+#[cfg(feature = "release")]
+pub type Bytes = PublicSeq<Byte>;
+#[cfg(not(feature = "release"))]
+pub type Bytes = Seq<Byte>;
+
+#[cfg(feature = "release")]
+#[macro_export]
+macro_rules! create_bytes {
+    ($( $b:expr ),+) => {
+        Bytes::from_vec(
+            vec![
+                $(
+                    $b
+                ),+
+            ]
+        )
+    };
+}
+
+#[cfg(not(feature = "release"))]
+#[macro_export]
+macro_rules! create_bytes {
+    ($( $b:expr ),+) => {
+        Bytes::from_vec(
+            vec![
+                $(
+                    U8($b)
+                ),+
+            ]
+        )
+    };
+}
+
+impl PublicSeq<u8> {
+    #[inline(always)]
+    #[cfg_attr(feature = "use_attributes", not_hacspec)]
+    pub fn from_public_slice(v: &[u8]) -> PublicSeq<u8> {
+        Self { b: v.to_vec() }
+    }
+
+    #[inline(always)]
+    #[cfg_attr(feature = "use_attributes", not_hacspec)]
+    pub fn from_native(b: Vec<u8>) -> PublicSeq<u8> {
+        Self { b }
+    }
+
+    #[inline(always)]
+    #[cfg_attr(feature = "use_attributes", not_hacspec)]
+    pub fn to_native(&self) -> Vec<u8> {
+        self.b.clone()
+    }
+
+    #[inline(always)]
+    #[cfg_attr(feature = "use_attributes", not_hacspec)]
+    pub fn into_native(self) -> Vec<u8> {
+        self.b
+    }
+
+    #[inline(always)]
+    #[cfg_attr(feature = "use_attributes", not_hacspec)]
+    pub fn as_slice(&self) -> &[u8] {
+        self.b.as_slice()
+    }
+}
+
+impl Seq<U8> {
+    #[inline(always)]
+    #[cfg_attr(feature = "use_attributes", not_hacspec)]
+    pub fn from_native(b: Vec<u8>) -> Self {
+        Self::from_public_slice(&b)
+    }
+
+    #[cfg_attr(feature = "use_attributes", not_hacspec)]
+    pub fn as_slice(&self) -> Vec<u8> {
+        self.to_native()
+    }
+}
+
+#[cfg(feature = "release")]
+#[inline(always)]
+pub fn Byte(x: u8) -> Byte {
+    x
+}
+
+#[cfg(not(feature = "release"))]
+#[inline(always)]
+pub fn Byte(x: u8) -> Byte {
+    U8(x)
+}
+
+pub trait ByteTrait {
+    fn declassify(self) -> u8;
+}
+
+impl ByteTrait for u8 {
+    #[inline(always)]
+    fn declassify(self) -> u8 {
+        self
+    }
+}
+
+#[inline(always)]
+pub fn declassify_usize_from_U8(x: Byte) -> usize {
+    x.into()
+}
+
+// === FIXME: NOT BYTES ANYMORE - MOVE ===
+
+pub trait U16Trait {
+    fn into_bytes(self) -> Bytes;
+}
+impl U16Trait for u16 {
+    #[cfg(feature = "release")]
+    fn into_bytes(self) -> Bytes {
+        Bytes::from_native_slice(&u16::to_be_bytes(self))
+    }
+    #[cfg(not(feature = "release"))]
+    fn into_bytes(self) -> Bytes {
+        Bytes::from_seq(&U16_to_be_bytes(U16(self)))
+    }
+}
+#[cfg(not(feature = "release"))]
+impl U16Trait for U16 {
+    fn into_bytes(self) -> Bytes {
+        Bytes::from_seq(&U16_to_be_bytes(self))
+    }
+}
+
+pub trait U32Trait {
+    fn into_bytes(self) -> Bytes;
+}
+
+impl U32Trait for u32 {
+    #[cfg(feature = "release")]
+    fn into_bytes(self) -> Bytes {
+        Bytes::from_native_slice(&u32::to_be_bytes(self))
+    }
+
+    #[cfg(not(feature = "release"))]
+    fn into_bytes(self) -> Bytes {
+        Bytes::from_seq(&U32_to_be_bytes(U32(self)))
+    }
+}
+#[cfg(not(feature = "release"))]
+impl U32Trait for U32 {
+    fn into_bytes(self) -> Bytes {
+        Bytes::from_seq(&U32_to_be_bytes(self))
+    }
+}
+
+#[cfg(feature = "release")]
+#[inline(always)]
+pub fn DoubleByte(x: u16) -> DoubleByte {
+    x
+}
+
+#[cfg(not(feature = "release"))]
+#[inline(always)]
+pub fn DoubleByte(x: u16) -> DoubleByte {
+    U16(x)
+}
+
+#[cfg(feature = "release")]
+#[inline(always)]
+pub fn QuadByte(x: u32) -> QuadByte {
+    x
+}
+
+#[cfg(not(feature = "release"))]
+#[inline(always)]
+pub fn QuadByte(x: u32) -> QuadByte {
+    U32(x)
+}

--- a/lib/src/seq/bytes.rs
+++ b/lib/src/seq/bytes.rs
@@ -94,9 +94,10 @@ impl Seq<U8> {
         Self::from_public_slice(&b)
     }
 
+    #[inline(always)]
     #[cfg_attr(feature = "use_attributes", not_hacspec)]
-    pub fn as_slice(&self) -> Vec<u8> {
-        self.to_native()
+    pub fn as_slice(&self) -> &[U8] {
+        self.b.as_slice()
     }
 }
 
@@ -149,6 +150,12 @@ impl U16Trait for U16 {
         Bytes::from_seq(&U16_to_be_bytes(self))
     }
 }
+#[cfg(feature = "release")]
+impl U16Trait for U16 {
+    fn into_bytes(self) -> Bytes {
+        Bytes::from_native(u16::to_be_bytes(self.0).to_vec())
+    }
+}
 
 pub trait U32Trait {
     fn into_bytes(self) -> Bytes;
@@ -169,6 +176,12 @@ impl U32Trait for u32 {
 impl U32Trait for U32 {
     fn into_bytes(self) -> Bytes {
         Bytes::from_seq(&U32_to_be_bytes(self))
+    }
+}
+#[cfg(feature = "release")]
+impl U32Trait for U32 {
+    fn into_bytes(self) -> Bytes {
+        Bytes::from_native(u32::to_be_bytes(self.0).to_vec())
     }
 }
 

--- a/lib/tests/test_buffer.rs
+++ b/lib/tests/test_buffer.rs
@@ -1,0 +1,77 @@
+use hacspec_lib::{buf::ByteBuffer, *};
+
+#[test]
+fn create() {
+    let s1 = Bytes::from_hex("deadbeef");
+    let s2 = Bytes::from_hex("02deadbeef");
+    let s3 = Bytes::from_hex("03deadbeef");
+    let s4 = Bytes::from_hex("04deadbeef");
+
+    let buffer = ByteBuffer::from_seq(s1);
+    let buffer = buffer.concat_owned(s2);
+    let buffer = buffer.concat_owned(s3);
+    let buffer = buffer.concat_owned(s4);
+
+    assert_secret_seq_eq!(
+        Bytes::from_hex("deadbeef02deadbeef03deadbeef04deadbeef"),
+        buffer.to_bytes(),
+        Byte
+    );
+}
+
+#[test]
+fn split() {
+    let s1 = Bytes::from_hex("deadbeef");
+    let s2 = Bytes::from_hex("02deadbeef");
+    let s3 = Bytes::from_hex("03deadbeef");
+    let s4 = Bytes::from_hex("04deadbeef");
+
+    let buffer = ByteBuffer::from_seq(s1);
+    let buffer = buffer.concat_owned(s2);
+    let buffer = buffer.concat_owned(s3);
+    let buffer = buffer.concat_owned(s4);
+
+    // get something shorter than the first bytes
+    let (l3_bytes, remainder) = buffer.clone().split_off(3);
+
+    assert_secret_seq_eq!(
+        Bytes::from_hex("ef02deadbeef03deadbeef04deadbeef"),
+        remainder.to_bytes(),
+        Byte
+    );
+
+    assert_secret_seq_eq!(Bytes::from_hex("deadbe"), l3_bytes, Byte);
+
+    // get something equal to the length of the first bytes
+    let (l4_bytes, remainder) = buffer.clone().split_off(4);
+
+    assert_secret_seq_eq!(
+        Bytes::from_hex("02deadbeef03deadbeef04deadbeef"),
+        remainder.to_bytes(),
+        Byte
+    );
+
+    assert_secret_seq_eq!(Bytes::from_hex("deadbeef"), l4_bytes, Byte);
+
+    // get something larger than the first bytes
+    let (l7_bytes, remainder) = buffer.clone().split_off(7);
+
+    assert_secret_seq_eq!(
+        Bytes::from_hex("beef03deadbeef04deadbeef"),
+        remainder.to_bytes(),
+        Byte
+    );
+
+    assert_secret_seq_eq!(Bytes::from_hex("deadbeef02dead"), l7_bytes, Byte);
+
+    // get something larger than the first bytes
+    let (l9_bytes, remainder) = buffer.clone().split_off(9);
+
+    assert_secret_seq_eq!(
+        Bytes::from_hex("03deadbeef04deadbeef"),
+        remainder.to_bytes(),
+        Byte
+    );
+
+    assert_secret_seq_eq!(Bytes::from_hex("deadbeef02deadbeef"), l9_bytes, Byte);
+}


### PR DESCRIPTION
This adds the option to transparently use `u8` instead of `U8` for efficient implementations.
Instead of `Seq<U8>`, `Bytes` and `Byte` can be used. `Byte` is `u8` when `features = "release"` and `U8` otherwise.